### PR TITLE
Add lost flag to item page

### DIFF
--- a/frontend/src/pages/ItemPage.tsx
+++ b/frontend/src/pages/ItemPage.tsx
@@ -25,6 +25,7 @@ export interface ItemDto {
   metatext?: string;
   is_staging?: boolean;
   is_deleted?: boolean;
+  is_lost?: boolean;
   date_reminder?: string | null; // ISO timestamp or null
   product_code?: string;
   url?: string; // purchase url
@@ -51,6 +52,7 @@ const EMPTY_ITEM: ItemDto = {
   is_consumable: false,
   is_staging: true,
   is_deleted: false,
+  is_lost: false,
   date_creation: null,
   date_last_modified: null,
   date_purchased: null,
@@ -110,6 +112,7 @@ const booleanFlags = [
   { key: "is_consumable",     emoji: "🍽️", label: "Consumable" },
   { key: "is_staging",        emoji: "⏳", label: "Staging" },
   { key: "is_deleted",        emoji: "🗑️", label: "Deleted" },
+  { key: "is_lost",           emoji: "👻", label: "Lost" },
 ] as const;
 
 type FlagKey = typeof booleanFlags[number]["key"];


### PR DESCRIPTION
## Summary
- add the `is_lost` flag to the item DTO and default state
- expose the new flag in the boolean toggle list with a 👻 icon

## Testing
- npm run -w frontend build

------
https://chatgpt.com/codex/tasks/task_e_68d2ea5a4bd4832b831d54a348bb8cfa