### PR TITLE
Improve direct identifier lookups

### DIFF
--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 import logging
+import uuid
 
 from flask import Blueprint, jsonify, request
 
@@ -12,6 +13,7 @@ from .user_login import login_required
 from .db import get_or_create_session
 from .search_expression import SearchQuery
 from .slugify import slugify
+from .helpers import fuzzy_levenshtein_at_most
 
 from sqlalchemy import text
 
@@ -51,10 +53,84 @@ def _row_to_dict(row: Dict[str, Any]) -> Dict[str, Any]:
     return d
 
 
+def _normalize_primary_key_column(primary_key_column: str) -> str:
+    if not isinstance(primary_key_column, str):
+        raise TypeError("primary_key_column must be provided as a string")
+
+    column = primary_key_column.strip()
+    if not column:
+        raise ValueError("primary_key_column cannot be empty")
+
+    if not column.isidentifier():
+        raise ValueError("primary_key_column must be a valid identifier string")
+
+    return column
+
+
+def _unsigned_to_signed_32(value: int) -> int:
+    masked = value & 0xFFFFFFFF
+    if masked >= 0x80000000:
+        return masked - 0x100000000
+    return masked
+
+
+def _short_id_candidates(identifier: str) -> List[int]:
+    token = (identifier or "").strip()
+    if not token:
+        return []
+
+    candidates: List[int] = []
+
+    try:
+        hex_value = int(token, 16)
+    except ValueError:
+        hex_value = None
+
+    if hex_value is not None:
+        candidates.append(_unsigned_to_signed_32(hex_value))
+
+    digit_token = token.lstrip("+-")
+    if digit_token.isdigit():
+        try:
+            decimal_value = int(token, 10)
+        except ValueError:
+            decimal_value = None
+        else:
+            decimal_value = _unsigned_to_signed_32(decimal_value)
+            if decimal_value not in candidates:
+                candidates.append(decimal_value)
+
+    return candidates
+
+
+def _pick_best_short_id_row(
+    rows: List[Mapping[str, Any]],
+    comparison_text: str,
+) -> Mapping[str, Any]:
+    if len(rows) == 1:
+        return rows[0]
+
+    comparison_text_norm = comparison_text.lower()
+
+    def _distance(row: Mapping[str, Any]) -> tuple[int, str]:
+        name = str(row.get("name") or "")
+        name_norm = name.lower()
+        limit = max(len(comparison_text_norm), len(name_norm), 1)
+        dist = fuzzy_levenshtein_at_most(
+            comparison_text_norm,
+            name_norm,
+            limit=limit,
+        )
+        return (dist, name_norm)
+
+    return min(rows, key=_distance)
+
+
 def search_items(
     raw_query: str,
     target_uuid: Optional[str] = None,
     context: Any = None,
+    primary_key_column: str = "id",
 ) -> List[Dict[str, Any]]:
     """
     Execute an item search.
@@ -68,6 +144,8 @@ def search_items(
         NOTE: The base text search always runs regardless.
     context : Any
         Optional execution context; may contain request/session info later.
+    primary_key_column : str
+        Column name to use when resolving direct UUID lookups. Defaults to "id".
 
     Returns
     -------
@@ -83,6 +161,60 @@ def search_items(
 
     # Parse the query and extract normalized free-text
     sq = SearchQuery(s=raw_query, context=context)
+
+    if not target_uuid and len(sq.identifiers) == 1:
+        identifier = sq.identifiers[0]
+
+        uuid_candidate: Optional[str]
+        try:
+            uuid_candidate = str(uuid.UUID(identifier))
+        except (ValueError, AttributeError, TypeError):
+            uuid_candidate = None
+
+        if uuid_candidate and not (sq.query_text or "").strip():
+            column = _normalize_primary_key_column(primary_key_column)
+
+            direct_sql = text(
+                f"""
+                SELECT
+                    i.*
+                FROM items AS i
+                WHERE
+                    NOT i.is_deleted
+                    AND i.{column} = :identifier
+                LIMIT 1
+                """
+            )
+
+            row = session.execute(direct_sql, {"identifier": uuid_candidate}).mappings().first()
+            if row:
+                return [_row_to_dict(row)]
+        else:
+            short_id_values = _short_id_candidates(identifier)
+            if short_id_values:
+                comparison_text = (sq.query_text or "").strip() or raw_query.strip()
+                short_sql = text(
+                    """
+                    SELECT
+                        i.*
+                    FROM items AS i
+                    WHERE
+                        NOT i.is_deleted
+                        AND i.short_id = :short_id
+                    """
+                )
+
+                for value in short_id_values:
+                    sid_rows = session.execute(short_sql, {"short_id": value}).mappings().all()
+                    if not sid_rows:
+                        continue
+
+                    if comparison_text:
+                        best_row = _pick_best_short_id_row(sid_rows, comparison_text)
+                        return [_row_to_dict(best_row)]
+
+                    return [_row_to_dict(sid_rows[0])]
+
     query_text = sq.query_text or raw_query  # fallback just in case
 
     # --- BASE TEXT SEARCH (placeholder you will extend later) ---


### PR DESCRIPTION
## Summary
- add helpers to validate the primary-key column override and to normalize short-id values before querying
- confirm UUID identifiers with `uuid.UUID` before running the direct primary-key lookup
- try both hexadecimal and decimal interpretations of short ids and reuse fuzzy name matching to disambiguate duplicates

## Testing
- python -m compileall backend/app/search.py

------
https://chatgpt.com/codex/tasks/task_e_68d2fbe12318832b86ca962d96a15ff2