### PR TITLE
Add subtle footer and help placeholder page

### DIFF
--- a/frontend/src/app/Shell.tsx
+++ b/frontend/src/app/Shell.tsx
@@ -42,14 +42,40 @@ const Shell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
       </Container>
     </Navbar>
     <Container
+      style={{
+        marginTop: 0,
+        marginBottom: 0,
+        paddingTop: 0,
+        paddingBottom: 0,
+      }}
+      className="pb-5"
+    >
+      {children}
+      <footer
         style={{
-          marginTop: 0,
-          marginBottom: 0,
-          paddingTop: 0,
-          paddingBottom: 0,
+          marginTop: "1.5rem",
+          paddingTop: "0.5rem",
+          borderTop: "1px solid rgba(0, 0, 0, 0.08)",
+          fontSize: "0.75rem",
+          display: "flex",
+          gap: "0.75rem",
+          flexWrap: "wrap",
+          color: "#6c757d",
         }}
-        className="pb-5"
-      >{children}</Container>
+      >
+        <a
+          href="http://github.com/frank26080115/Junk-Warehouse"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: "inherit", textDecoration: "none" }}
+        >
+          Junk-Warehouse @ GitHub
+        </a>
+        <a href="/help.md" style={{ color: "inherit", textDecoration: "none" }}>
+          🙋ℹ️
+        </a>
+      </footer>
+    </Container>
   </>
 );
 

--- a/help.md
+++ b/help.md
@@ -1,0 +1,3 @@
+# Help
+
+This placeholder page will be expanded with documentation in the future.


### PR DESCRIPTION
## Summary
- add a subtle footer in the shared Shell layout with links to GitHub and help content
- add a placeholder help.md file at the repository root for future documentation

## Testing
- npm run -w frontend build

------
https://chatgpt.com/codex/tasks/task_e_68d3070e11b8832ba78dcfc3d9d2e257