### PR TITLE
Add maintenance task endpoint and admin UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from .static_server import bp_overlay, get_public_html_path
 from .imagehandler import bp_image
 from .user_login import bp as bp_auth
 from .items import bp as bp_items
+from .maint import bp as bp_maint
 from .search import bp as bp_search
 import app.helpers as helpers
 import app.db as db
@@ -43,6 +44,7 @@ def create_app():
     app.register_blueprint(bp_image)
     app.register_blueprint(bp_search)
     app.register_blueprint(bp_items)
+    app.register_blueprint(bp_maint)
 
     # Load JSON (silently ignore if missing/bad)
     try:

--- a/backend/app/maint.py
+++ b/backend/app/maint.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Mapping
+
+from flask import Blueprint, current_app, jsonify, request
+
+from .user_login import login_required
+from services import maintenance
+
+log = logging.getLogger(__name__)
+
+bp = Blueprint("maintenance", __name__, url_prefix="/api")
+
+
+def _ensure_datetime(value: Any) -> datetime:
+    if value is None:
+        raise ValueError("A cutoff datetime is required.")
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, (int, float)):
+        tz = current_app.config.get("TZ")
+        if tz is not None:
+            dt = datetime.fromtimestamp(value, tz)
+        else:
+            dt = datetime.fromtimestamp(value)
+    elif isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            raise ValueError("A cutoff datetime is required.")
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError as exc:
+            raise ValueError(f"Invalid ISO datetime value: {raw}") from exc
+    else:
+        raise ValueError("Cutoff datetime must be a datetime, ISO string, or timestamp.")
+
+    if dt.tzinfo is None:
+        tz = current_app.config.get("TZ")
+        if tz is not None:
+            dt = dt.replace(tzinfo=tz)
+    return dt
+
+
+def _collect_parameters(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+    nested = payload.get("parameters")
+    if isinstance(nested, Mapping):
+        params.update(nested)
+    for key, value in payload.items():
+        if key in {"task", "parameters"}:
+            continue
+        params.setdefault(key, value)
+    return params
+
+
+def _execute_task(task_name: str, params: Mapping[str, Any]):
+    if task_name == "prune_deleted":
+        return maintenance.prune_deleted()
+    if task_name == "prune_stale_staging_items":
+        cutoff_value = params.get("cutoff_date") or params.get("cutoff")
+        cutoff = _ensure_datetime(cutoff_value)
+        return maintenance.prune_stale_staging_items(cutoff)
+    if task_name == "prune_stale_staging_invoices":
+        cutoff_value = params.get("cutoff_date") or params.get("cutoff")
+        cutoff = _ensure_datetime(cutoff_value)
+        return maintenance.prune_stale_staging_invoices(cutoff)
+    if task_name == "prune_images":
+        target_raw = (
+            params.get("target_directory")
+            or params.get("directory")
+            or params.get("path")
+        )
+        if target_raw is None:
+            raise ValueError("The 'target_directory' parameter is required for prune_images.")
+        target_text = str(target_raw).strip()
+        if not target_text:
+            raise ValueError("The 'target_directory' parameter is required for prune_images.")
+        return maintenance.prune_images(target_text)
+    raise ValueError(f"Unknown task '{task_name}'.")
+
+
+@bp.post("/task")
+@login_required
+def run_task():
+    data = request.get_json(silent=True)
+    if not isinstance(data, Mapping):
+        data = request.form.to_dict(flat=True)
+    if not isinstance(data, Mapping) or not data:
+        return jsonify({"error": "Missing request payload."}), 400
+
+    task_name = str(data.get("task") or "").strip()
+    if not task_name:
+        return jsonify({"error": "Missing 'task' parameter."}), 400
+
+    params = _collect_parameters(data)
+
+    log.info("Running maintenance task %s", task_name)
+    try:
+        result = _execute_task(task_name, params)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception as exc:  # pragma: no cover - unexpected failure handling
+        log.exception("Maintenance task %s failed", task_name)
+        return jsonify({"error": "Task failed.", "details": str(exc)}), 500
+
+    return jsonify({"task": task_name, "result": result}), 200

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,11 +1,278 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
 
-const AdminPage: React.FC = () => (
-  <div>
-    <h1>Admin</h1>
-    <p>Run maintenance tasks here.</p>
-    {/* TODO: buttons / status panes that call /api/admin/* */}
-  </div>
-);
+type TaskName =
+  | "prune_deleted"
+  | "prune_stale_staging_items"
+  | "prune_stale_staging_invoices"
+  | "prune_images";
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid #d0d0d0",
+  borderRadius: "8px",
+  padding: "16px",
+  marginBottom: "16px",
+  backgroundColor: "#fafafa",
+};
+
+const statusTextStyle: React.CSSProperties = {
+  marginTop: "8px",
+  fontStyle: "italic",
+  color: "#555555",
+};
+
+const inputGroupStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  marginTop: "8px",
+  marginBottom: "8px",
+};
+
+const resultBoxStyle: React.CSSProperties = {
+  marginTop: "12px",
+  padding: "12px",
+  backgroundColor: "#f5f5f5",
+  borderRadius: "4px",
+  whiteSpace: "pre-wrap",
+  fontFamily: "Menlo, Monaco, Consolas, 'Courier New', monospace",
+  fontSize: "0.9rem",
+};
+
+const taskTitles: Record<TaskName, string> = {
+  prune_deleted: "Prune Soft-Deleted Records",
+  prune_stale_staging_items: "Prune Stale Staging Items",
+  prune_stale_staging_invoices: "Prune Stale Staging Invoices",
+  prune_images: "Prune Unused Images",
+};
+
+const AdminPage: React.FC = () => {
+  const [activeTask, setActiveTask] = useState<TaskName | null>(null);
+  const [lastTask, setLastTask] = useState<TaskName | null>(null);
+  const [resultText, setResultText] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [itemsCutoff, setItemsCutoff] = useState<string>("");
+  const [invoicesCutoff, setInvoicesCutoff] = useState<string>("");
+  const [imageDirectory, setImageDirectory] = useState<string>("");
+
+  const busy = activeTask !== null;
+
+  const runTask = useCallback(
+    async (task: TaskName, parameters: Record<string, unknown>) => {
+      if (activeTask) {
+        return;
+      }
+
+      setActiveTask(task);
+      setLastTask(task);
+      setError(null);
+      setResultText(null);
+
+      try {
+        const response = await fetch("/api/task", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ task, parameters }),
+        });
+
+        const responseText = await response.text();
+        let payload: unknown = null;
+
+        if (responseText) {
+          try {
+            payload = JSON.parse(responseText);
+          } catch {
+            payload = responseText;
+          }
+        }
+
+        if (!response.ok) {
+          if (
+            payload &&
+            typeof payload === "object" &&
+            "error" in payload &&
+            typeof (payload as { error: unknown }).error === "string"
+          ) {
+            setError((payload as { error: string }).error);
+          } else {
+            setError(`Task failed with status ${response.status}.`);
+          }
+          return;
+        }
+
+        if (
+          payload &&
+          typeof payload === "object" &&
+          "result" in payload
+        ) {
+          const resultValue = (payload as { result: unknown }).result;
+          setResultText(JSON.stringify(resultValue, null, 2));
+        } else if (typeof payload === "string") {
+          setResultText(payload);
+        } else if (payload != null) {
+          setResultText(JSON.stringify(payload, null, 2));
+        } else {
+          setResultText("Task completed.");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setActiveTask(null);
+      }
+    },
+    [activeTask],
+  );
+
+  const handlePruneDeleted = () => {
+    runTask("prune_deleted", {});
+  };
+
+  const handlePruneStagingItems = () => {
+    if (!itemsCutoff) {
+      setError("Please choose a cutoff date for staging items.");
+      return;
+    }
+    runTask("prune_stale_staging_items", { cutoff_date: itemsCutoff });
+  };
+
+  const handlePruneStagingInvoices = () => {
+    if (!invoicesCutoff) {
+      setError("Please choose a cutoff date for staging invoices.");
+      return;
+    }
+    runTask("prune_stale_staging_invoices", { cutoff_date: invoicesCutoff });
+  };
+
+  const handlePruneImages = () => {
+    const trimmed = imageDirectory.trim();
+    if (!trimmed) {
+      setError("Please provide the target directory for image pruning.");
+      return;
+    }
+    runTask("prune_images", { target_directory: trimmed });
+  };
+
+  return (
+    <div style={{ maxWidth: "800px", margin: "0 auto", padding: "1rem" }}>
+      <h1>Admin</h1>
+      <p>Run maintenance tasks here.</p>
+
+      <section style={sectionStyle}>
+        <h2>{taskTitles.prune_deleted}</h2>
+        <p>Permanently removes rows that were previously marked as deleted.</p>
+        <button type="button" onClick={handlePruneDeleted} disabled={busy}>
+          Run task
+        </button>
+        {activeTask === "prune_deleted" && (
+          <p style={statusTextStyle}>Busy, please wait...</p>
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <h2>{taskTitles.prune_stale_staging_items}</h2>
+        <p>
+          Marks staging items as deleted when they were last modified before your
+          selected cutoff date.
+        </p>
+        <div style={inputGroupStyle}>
+          <label htmlFor="staging-items-cutoff">Cutoff date</label>
+          <input
+            id="staging-items-cutoff"
+            type="datetime-local"
+            value={itemsCutoff}
+            onChange={(event) => setItemsCutoff(event.target.value)}
+            disabled={busy}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handlePruneStagingItems}
+          disabled={busy || !itemsCutoff}
+        >
+          Run task
+        </button>
+        {activeTask === "prune_stale_staging_items" && (
+          <p style={statusTextStyle}>Busy, please wait...</p>
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <h2>{taskTitles.prune_stale_staging_invoices}</h2>
+        <p>
+          Marks invoices that have snoozed beyond the cutoff as deleted so they stop
+          appearing in staging queues.
+        </p>
+        <div style={inputGroupStyle}>
+          <label htmlFor="staging-invoices-cutoff">Cutoff date</label>
+          <input
+            id="staging-invoices-cutoff"
+            type="datetime-local"
+            value={invoicesCutoff}
+            onChange={(event) => setInvoicesCutoff(event.target.value)}
+            disabled={busy}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handlePruneStagingInvoices}
+          disabled={busy || !invoicesCutoff}
+        >
+          Run task
+        </button>
+        {activeTask === "prune_stale_staging_invoices" && (
+          <p style={statusTextStyle}>Busy, please wait...</p>
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <h2>{taskTitles.prune_images}</h2>
+        <p>
+          Removes database entries and files for images that are deleted or no longer
+          associated with any items.
+        </p>
+        <div style={inputGroupStyle}>
+          <label htmlFor="image-target-directory">Target directory</label>
+          <input
+            id="image-target-directory"
+            type="text"
+            placeholder="Absolute path to the image directory"
+            value={imageDirectory}
+            onChange={(event) => setImageDirectory(event.target.value)}
+            disabled={busy}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handlePruneImages}
+          disabled={busy || imageDirectory.trim() === ""}
+        >
+          Run task
+        </button>
+        {activeTask === "prune_images" && (
+          <p style={statusTextStyle}>Busy, please wait...</p>
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <h2>Task status</h2>
+        {busy && <p style={statusTextStyle}>Busy, please wait...</p>}
+        {lastTask ? (
+          <p>Last task: {taskTitles[lastTask]}</p>
+        ) : (
+          <p>No tasks have been run yet.</p>
+        )}
+        {error && (
+          <p style={{ color: "#b30000", marginTop: "8px" }} role="alert">
+            {error}
+          </p>
+        )}
+        {resultText && (
+          <pre style={resultBoxStyle}>{resultText}</pre>
+        )}
+      </section>
+    </div>
+  );
+};
 
 export default AdminPage;


### PR DESCRIPTION
## Summary
- add a Flask maintenance blueprint that exposes `/api/task` and routes the supported housekeeping functions
- register the maintenance blueprint during application initialization
- expand the admin page with controls to trigger each maintenance task, collect parameters, and show task status

## Testing
- npm run lint *(fails: existing lint errors in unrelated backend files)*

------
https://chatgpt.com/codex/tasks/task_e_68d32ba526f4832b898f86683214c802