### PR TITLE
Respect explicit is_staging flag on insert

### DIFF
--- a/backend/app/items.py
+++ b/backend/app/items.py
@@ -209,9 +209,9 @@ def insert_item(
     Insert a new item row and return the augmented item dict.
 
     This is the logic that powers the ``/api/insertitem`` endpoint and can be
-    re-used by offline scripts (e.g., CSV importers). ``is_staging`` is forced to
-    ``True`` for every inserted item so that bulk imports never go live by
-    accident.
+    re-used by offline scripts (e.g., CSV importers). ``is_staging`` defaults to
+    ``True`` for new rows so that bulk imports never go live by accident, but an
+    explicit ``False`` value from the caller is now respected.
     """
 
     if not isinstance(payload, Mapping):
@@ -270,7 +270,10 @@ def insert_item(
                 )
 
     data["short_id"] = short_id_value
-    data["is_staging"] = True
+    if data.get("is_staging") is None:
+        # Default new rows to staging unless the caller explicitly provided
+        # False.  (Truthiness is preserved; only ``None`` triggers the default.)
+        data["is_staging"] = True
 
     result = update_db_row_by_dict(
         engine=engine,


### PR DESCRIPTION
## Summary
- update the insert_item helper so it only defaults is_staging to true when the caller does not provide a value
- clarify the docstring to note that explicit False is preserved

## Testing
- `make lint` *(fails: repository already contains numerous lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d371601c2c832b9bdb4136e0077ed0