### PR TITLE
Use default image directory for maintenance tasks

### DIFF
--- a/backend/app/maint.py
+++ b/backend/app/maint.py
@@ -67,16 +67,19 @@ def _execute_task(task_name: str, params: Mapping[str, Any]):
         cutoff = _ensure_datetime(cutoff_value)
         return maintenance.prune_stale_staging_invoices(cutoff)
     if task_name == "prune_images":
-        target_raw = (
-            params.get("target_directory")
-            or params.get("directory")
-            or params.get("path")
-        )
+        target_raw = None
+        for key in ("target_directory", "directory", "path"):
+            if key in params:
+                target_raw = params.get(key)
+                break
+
         if target_raw is None:
-            raise ValueError("The 'target_directory' parameter is required for prune_images.")
+            return maintenance.prune_images()
+
         target_text = str(target_raw).strip()
         if not target_text:
-            raise ValueError("The 'target_directory' parameter is required for prune_images.")
+            return maintenance.prune_images()
+
         return maintenance.prune_images(target_text)
     raise ValueError(f"Unknown task '{task_name}'.")
 

--- a/backend/app/static_server.py
+++ b/backend/app/static_server.py
@@ -41,10 +41,12 @@ def overlay_root(path: str):
     # 4. Otherwise, not found
     abort(404)
 
-def get_public_html_path():
+def get_public_html_path() -> Path:
     from flask import current_app
-    k = "public_html_path"
-    d = REPO_ROOT / "var" / "public_html"
-    if k in current_app.config and current_app.config[k]:
-        return Path(current_app.config[k])
-    return d
+
+    key = "public_html_path"
+    default_path = REPO_ROOT / "var" / "public_html"
+    configured_path = current_app.config.get(key)
+    if configured_path:
+        return Path(configured_path)
+    return default_path

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -52,7 +52,6 @@ const AdminPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [itemsCutoff, setItemsCutoff] = useState<string>("");
   const [invoicesCutoff, setInvoicesCutoff] = useState<string>("");
-  const [imageDirectory, setImageDirectory] = useState<string>("");
 
   const busy = activeTask !== null;
 
@@ -145,12 +144,7 @@ const AdminPage: React.FC = () => {
   };
 
   const handlePruneImages = () => {
-    const trimmed = imageDirectory.trim();
-    if (!trimmed) {
-      setError("Please provide the target directory for image pruning.");
-      return;
-    }
-    runTask("prune_images", { target_directory: trimmed });
+    runTask("prune_images", {});
   };
 
   return (
@@ -179,7 +173,7 @@ const AdminPage: React.FC = () => {
           <label htmlFor="staging-items-cutoff">Cutoff date</label>
           <input
             id="staging-items-cutoff"
-            type="datetime-local"
+            type="date"
             value={itemsCutoff}
             onChange={(event) => setItemsCutoff(event.target.value)}
             disabled={busy}
@@ -207,7 +201,7 @@ const AdminPage: React.FC = () => {
           <label htmlFor="staging-invoices-cutoff">Cutoff date</label>
           <input
             id="staging-invoices-cutoff"
-            type="datetime-local"
+            type="date"
             value={invoicesCutoff}
             onChange={(event) => setInvoicesCutoff(event.target.value)}
             disabled={busy}
@@ -229,23 +223,12 @@ const AdminPage: React.FC = () => {
         <h2>{taskTitles.prune_images}</h2>
         <p>
           Removes database entries and files for images that are deleted or no longer
-          associated with any items.
+          associated with any items using the server's default image directory.
         </p>
-        <div style={inputGroupStyle}>
-          <label htmlFor="image-target-directory">Target directory</label>
-          <input
-            id="image-target-directory"
-            type="text"
-            placeholder="Absolute path to the image directory"
-            value={imageDirectory}
-            onChange={(event) => setImageDirectory(event.target.value)}
-            disabled={busy}
-          />
-        </div>
         <button
           type="button"
           onClick={handlePruneImages}
-          disabled={busy || imageDirectory.trim() === ""}
+          disabled={busy}
         >
           Run task
         </button>


### PR DESCRIPTION
## Summary
- allow the maintenance image pruning task to fall back to the configured public HTML directory when no path is provided
- update the maintenance API helper to tolerate missing image directory parameters and annotate the static server helper
- simplify the admin page by removing the manual directory field and switching cutoff pickers to date-only inputs

## Testing
- npm run lint *(fails: existing lint errors in backend tooling and helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d37c818434832baad0f79ecf3201a1