### PR TITLE
Update association helpers and UI for bit flags

### DIFF
--- a/backend/app/assoc_helper.py
+++ b/backend/app/assoc_helper.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+CONTAINMENT_BIT = 1
+RELATED_BIT = 2
+SIMILAR_BIT = 4
+
+ALL_ASSOCIATION_BITS = (
+    CONTAINMENT_BIT,
+    RELATED_BIT,
+    SIMILAR_BIT,
+)
+ALL_ASSOCIATION_MASK = 0
+for _bit in ALL_ASSOCIATION_BITS:
+    ALL_ASSOCIATION_MASK |= _bit
+
+default_words = {
+    CONTAINMENT_BIT: "containment",
+    RELATED_BIT: "related",
+    SIMILAR_BIT: "similar",
+}
+BIT_TO_WORD = dict(default_words)
+WORD_TO_BIT = {value: key for key, value in BIT_TO_WORD.items()}
+BIT_TO_EMOJI_HTML_ENTITY = {
+    CONTAINMENT_BIT: "&#x1F5C3;",
+    RELATED_BIT: "&#x1F517;",
+    SIMILAR_BIT: "&#x1F46F;",
+}
+BIT_TO_EMOJI_CHARACTER = {
+    CONTAINMENT_BIT: "🗃️",
+    RELATED_BIT: "🔗",
+    SIMILAR_BIT: "👯",
+}
+
+
+def bit_to_word(bit: int) -> str:
+    return BIT_TO_WORD.get(bit, "")
+
+
+def word_to_bit(word: str | None) -> int:
+    if word is None:
+        return 0
+    normalized = word.strip().lower()
+    return WORD_TO_BIT.get(normalized, 0)
+
+
+def bit_to_emoji_html_entity(bit: int) -> str:
+    return BIT_TO_EMOJI_HTML_ENTITY.get(bit, "")
+
+
+def bit_to_emoji_character(bit: int) -> str:
+    return BIT_TO_EMOJI_CHARACTER.get(bit, "")
+
+
+def int_has_containment(value: int) -> bool:
+    return bool(value & CONTAINMENT_BIT)
+
+
+def int_has_related(value: int) -> bool:
+    return bool(value & RELATED_BIT)
+
+
+def int_has_similar(value: int) -> bool:
+    return bool(value & SIMILAR_BIT)
+
+
+def collect_words_from_int(value: int) -> list[str]:
+    return [BIT_TO_WORD[bit] for bit in ALL_ASSOCIATION_BITS if value & bit]
+
+
+def collect_emoji_characters_from_int(value: int) -> list[str]:
+    return [BIT_TO_EMOJI_CHARACTER[bit] for bit in ALL_ASSOCIATION_BITS if value & bit]
+
+
+def collect_emoji_entities_from_int(value: int) -> list[str]:
+    return [BIT_TO_EMOJI_HTML_ENTITY[bit] for bit in ALL_ASSOCIATION_BITS if value & bit]

--- a/frontend/src/app/helpers/assocHelper.tsx
+++ b/frontend/src/app/helpers/assocHelper.tsx
@@ -1,0 +1,86 @@
+export const CONTAINMENT_BIT = 1;
+export const RELATED_BIT = 2;
+export const SIMILAR_BIT = 4;
+
+export const ALL_ASSOCIATION_BITS = [
+  CONTAINMENT_BIT,
+  RELATED_BIT,
+  SIMILAR_BIT,
+] as const;
+export const ALL_ASSOCIATION_MASK = ALL_ASSOCIATION_BITS.reduce(
+  (mask, bit) => mask | bit,
+  0,
+);
+
+const BIT_TO_WORD: Record<number, string> = {
+  [CONTAINMENT_BIT]: "containment",
+  [RELATED_BIT]: "related",
+  [SIMILAR_BIT]: "similar",
+};
+const WORD_TO_BIT: Record<string, number> = Object.entries(BIT_TO_WORD).reduce<
+  Record<string, number>
+>((accumulator, [bit, word]) => {
+  accumulator[word] = Number(bit);
+  return accumulator;
+}, {});
+
+const BIT_TO_EMOJI_HTML_ENTITY: Record<number, string> = {
+  [CONTAINMENT_BIT]: "&#x1F5C3;",
+  [RELATED_BIT]: "&#x1F517;",
+  [SIMILAR_BIT]: "&#x1F46F;",
+};
+const BIT_TO_EMOJI_CHARACTER: Record<number, string> = {
+  [CONTAINMENT_BIT]: "🗃️",
+  [RELATED_BIT]: "🔗",
+  [SIMILAR_BIT]: "👯",
+};
+
+export function bit_to_word(bit: number): string {
+  return BIT_TO_WORD[bit] ?? "";
+}
+
+export function word_to_bit(word: string | null | undefined): number {
+  if (!word) {
+    return 0;
+  }
+  const normalized = word.trim().toLowerCase();
+  return WORD_TO_BIT[normalized] ?? 0;
+}
+
+export function bit_to_emoji_html_entity(bit: number): string {
+  return BIT_TO_EMOJI_HTML_ENTITY[bit] ?? "";
+}
+
+export function bit_to_emoji_character(bit: number): string {
+  return BIT_TO_EMOJI_CHARACTER[bit] ?? "";
+}
+
+export function int_has_containment(value: number): boolean {
+  return (value & CONTAINMENT_BIT) === CONTAINMENT_BIT;
+}
+
+export function int_has_related(value: number): boolean {
+  return (value & RELATED_BIT) === RELATED_BIT;
+}
+
+export function int_has_similar(value: number): boolean {
+  return (value & SIMILAR_BIT) === SIMILAR_BIT;
+}
+
+export function collect_words_from_int(value: number): string[] {
+  return ALL_ASSOCIATION_BITS.filter((bit) => (value & bit) === bit).map((bit) =>
+    BIT_TO_WORD[bit],
+  );
+}
+
+export function collect_emoji_characters_from_int(value: number): string[] {
+  return ALL_ASSOCIATION_BITS.filter((bit) => (value & bit) === bit).map(
+    (bit) => BIT_TO_EMOJI_CHARACTER[bit],
+  );
+}
+
+export function collect_emoji_entities_from_int(value: number): string[] {
+  return ALL_ASSOCIATION_BITS.filter((bit) => (value & bit) === bit).map(
+    (bit) => BIT_TO_EMOJI_HTML_ENTITY[bit],
+  );
+}


### PR DESCRIPTION
## Summary
- add backend association helper utilities for the new bit-flag `assoc_type`
- expose matching TypeScript helpers and update the search panel to use the new bitmask model
- replace the relationship dropdown with emoji toggles and keep table icons in a single line

## Testing
- npm run lint *(fails: pre-existing lint errors in backend tools and helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68d449e48540832bb68e99dc99b65526