### PR TITLE
Add maintenance task to merge reciprocal relationships

### DIFF
--- a/backend/app/maint.py
+++ b/backend/app/maint.py
@@ -81,6 +81,22 @@ def _execute_task(task_name: str, params: Mapping[str, Any]):
             return maintenance.prune_images()
 
         return maintenance.prune_images(target_text)
+    if task_name == "neaten_relationship":
+        target = params.get("item_uuid")
+        if target is None:
+            for key in ("item_id", "uuid", "id"):
+                if key in params:
+                    target = params.get(key)
+                    break
+
+        if isinstance(target, str):
+            trimmed = target.strip()
+            if not trimmed:
+                target = None
+            else:
+                target = trimmed
+
+        return maintenance.neaten_relationship(item_uuid=target)
     raise ValueError(f"Unknown task '{task_name}'.")
 
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -4,7 +4,8 @@ type TaskName =
   | "prune_deleted"
   | "prune_stale_staging_items"
   | "prune_stale_staging_invoices"
-  | "prune_images";
+  | "prune_images"
+  | "neaten_relationship";
 
 const sectionStyle: React.CSSProperties = {
   border: "1px solid #d0d0d0",
@@ -43,6 +44,7 @@ const taskTitles: Record<TaskName, string> = {
   prune_stale_staging_items: "Prune Stale Staging Items",
   prune_stale_staging_invoices: "Prune Stale Staging Invoices",
   prune_images: "Prune Unused Images",
+  neaten_relationship: "Combine Reciprocal Relationships",
 };
 
 const AdminPage: React.FC = () => {
@@ -52,6 +54,7 @@ const AdminPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [itemsCutoff, setItemsCutoff] = useState<string>("");
   const [invoicesCutoff, setInvoicesCutoff] = useState<string>("");
+  const [relationshipUuid, setRelationshipUuid] = useState<string>("");
 
   const busy = activeTask !== null;
 
@@ -147,6 +150,15 @@ const AdminPage: React.FC = () => {
     runTask("prune_images", {});
   };
 
+  const handleNeatenRelationships = () => {
+    const payload: Record<string, unknown> = {};
+    const trimmed = relationshipUuid.trim();
+    if (trimmed) {
+      payload.item_uuid = trimmed;
+    }
+    runTask("neaten_relationship", payload);
+  };
+
   return (
     <div style={{ maxWidth: "800px", margin: "0 auto", padding: "1rem" }}>
       <h1>Admin</h1>
@@ -233,6 +245,36 @@ const AdminPage: React.FC = () => {
           Run task
         </button>
         {activeTask === "prune_images" && (
+          <p style={statusTextStyle}>Busy, please wait...</p>
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <h2>{taskTitles.neaten_relationship}</h2>
+        <p>
+          Merges opposite-direction relationship rows by combining their type flags
+          and removing redundant entries. Provide an item UUID to limit the scope or
+          leave blank to process all relationships.
+        </p>
+        <div style={inputGroupStyle}>
+          <label htmlFor="relationship-uuid">Item UUID (optional)</label>
+          <input
+            id="relationship-uuid"
+            type="text"
+            value={relationshipUuid}
+            onChange={(event) => setRelationshipUuid(event.target.value)}
+            placeholder="00000000-0000-0000-0000-000000000000"
+            disabled={busy}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleNeatenRelationships}
+          disabled={busy}
+        >
+          Run task
+        </button>
+        {activeTask === "neaten_relationship" && (
           <p style={statusTextStyle}>Busy, please wait...</p>
         )}
       </section>


### PR DESCRIPTION
## Summary
- add a maintenance helper that merges reciprocal relationship rows and combines their flags
- expose the new task through the maintenance API endpoint
- provide an admin page control for running the relationship cleanup with an optional item filter

## Testing
- npm run lint *(fails: existing lint issues in backend/app)*

------
https://chatgpt.com/codex/tasks/task_e_68d454f881a0832b83249a035de73ef1