### PR TITLE
Add scripts to normalize CRLF line endings

### DIFF
--- a/scripts/fix_all_line_endings.py
+++ b/scripts/fix_all_line_endings.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def get_repo_files() -> list[Path]:
+    result = subprocess.check_output(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        text=True,
+    )
+    return [Path(line) for line in result.splitlines() if line]
+
+
+def normalize_to_crlf(path: Path) -> bool:
+    data = path.read_bytes()
+    if b"\0" in data or b"\r\n" not in data:
+        return False
+
+    normalized = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    converted = normalized.replace(b"\n", b"\r\n")
+
+    if converted != data:
+        path.write_bytes(converted)
+        return True
+
+    return False
+
+
+def main() -> None:
+    repo_root = Path.cwd()
+    changed: list[Path] = []
+
+    for rel_path in get_repo_files():
+        file_path = repo_root / rel_path
+        if not file_path.is_file():
+            continue
+
+        try:
+            updated = normalize_to_crlf(file_path)
+        except OSError as exc:
+            print(f"Skipping {rel_path}: {exc}")
+            continue
+
+        if updated:
+            changed.append(rel_path)
+
+    if changed:
+        print("Updated line endings for:")
+        for path in changed:
+            print(f" - {path}")
+    else:
+        print("No files required updates.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_all_line_endings.sh
+++ b/scripts/fix_all_line_endings.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -t files < <(git ls-files --cached --others --exclude-standard)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No files to process."
+  exit 0
+fi
+
+updated=()
+
+for file in "${files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    continue
+  fi
+
+  if LC_ALL=C grep -q $'\0' -- "$file"; then
+    continue
+  fi
+
+  if ! LC_ALL=C grep -q $'\r\n' -- "$file"; then
+    continue
+  fi
+
+  tmp_file=$(mktemp)
+  perl -0pe 's/\r\n?|\n/\r\n/g' -- "$file" >"$tmp_file"
+
+  if ! cmp -s "$file" "$tmp_file"; then
+    mv "$tmp_file" "$file"
+    updated+=("$file")
+  else
+    rm "$tmp_file"
+  fi
+done
+
+if [[ ${#updated[@]} -gt 0 ]]; then
+  echo "Updated line endings for:"
+  for file in "${updated[@]}"; do
+    echo " - $file"
+  done
+else
+  echo "No files required updates."
+fi


### PR DESCRIPTION
## Summary
- add a Python helper that enforces CRLF endings for text files that already contain CRLF sequences
- add a shell script counterpart that performs the same normalization using Unix utilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d45f80e4f8832b88c83b41955b6031