### PR TITLE
Implement invoice detail editing page

### DIFF
--- a/frontend/src/pages/InvoicePage.tsx
+++ b/frontend/src/pages/InvoicePage.tsx
@@ -1,13 +1,374 @@
-import React from "react";
-import { useParams } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import "../styles/forms.css";
+
+interface InvoiceDto {
+  id?: string;
+  date?: string | null;
+  order_number?: string;
+  shop_name?: string;
+  urls?: string;
+  subject?: string;
+  html?: string;
+  has_been_processed?: boolean;
+  snooze?: string | null;
+  is_deleted?: boolean;
+}
+
+const EMPTY_INVOICE: InvoiceDto = {
+  id: "",
+  date: null,
+  order_number: "",
+  shop_name: "",
+  urls: "",
+  subject: "",
+  html: "",
+  has_been_processed: false,
+  snooze: null,
+  is_deleted: false,
+};
+
+function fmtDateTime(value?: string | null): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(+date)) return "";
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  const hours = `${date.getHours()}`.padStart(2, "0");
+  const minutes = `${date.getMinutes()}`.padStart(2, "0");
+  return `${year}/${month}/${day} ${hours}:${minutes}`;
+}
+
+function toDateInputValue(value?: string | null): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(+date)) return "";
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function fromDateInputValue(value: string): string | null {
+  if (!value) return null;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return null;
+  const date = new Date(year, month - 1, day, 0, 0, 0);
+  return date.toISOString();
+}
+
+function splitUrls(value?: string): string[] {
+  if (!value) return [];
+  return value
+    .split(";")
+    .map((url) => url.trim())
+    .filter((url) => url.length > 0);
+}
 
 const InvoicePage: React.FC = () => {
   const { uuid } = useParams();
+  const navigate = useNavigate();
+  const isNewInvoice = !uuid || uuid === "new";
+  const [invoice, setInvoice] = useState<InvoiceDto>({ ...EMPTY_INVOICE });
+  const [snapshot, setSnapshot] = useState<InvoiceDto>({ ...EMPTY_INVOICE });
+  const [isReadOnly, setIsReadOnly] = useState<boolean>(() => !isNewInvoice);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const [success, setSuccess] = useState<string>("");
+  const [htmlExpanded, setHtmlExpanded] = useState<boolean>(false);
+
+  useEffect(() => {
+    let ignore = false;
+    async function load() {
+      if (isNewInvoice) {
+        const blank = { ...EMPTY_INVOICE };
+        if (!ignore) {
+          setInvoice(blank);
+          setSnapshot(blank);
+          setIsReadOnly(false);
+        }
+        return;
+      }
+      try {
+        setLoading(true);
+        setError("");
+        const res = await fetch("/api/getinvoice", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uuid }),
+        });
+        if (!res.ok) throw new Error(`GET failed: ${res.status}`);
+        const data: InvoiceDto = await res.json();
+        if (!ignore) {
+          const merged = { ...EMPTY_INVOICE, ...data };
+          setInvoice(merged);
+          setSnapshot(merged);
+          setIsReadOnly(true);
+        }
+      } catch (e: any) {
+        console.error(e);
+        if (!ignore) {
+          setError(e?.message || "Failed to load invoice");
+        }
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [uuid, isNewInvoice]);
+
+  const urlEntries = useMemo(() => splitUrls(invoice.urls), [invoice.urls]);
+
+  const snoozeNeedsAttention = useMemo(() => {
+    if (invoice.has_been_processed) return false;
+    if (!invoice.snooze) return false;
+    const date = new Date(invoice.snooze);
+    if (Number.isNaN(+date)) return false;
+    const snoozeDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const today = new Date();
+    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    return snoozeDay < todayStart;
+  }, [invoice.has_been_processed, invoice.snooze]);
+
+  const handleFieldChange = (key: keyof InvoiceDto, value: InvoiceDto[keyof InvoiceDto]) => {
+    if (isReadOnly) return;
+    setInvoice((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleToggleDeleted = () => {
+    if (isReadOnly) return;
+    setInvoice((prev) => ({ ...prev, is_deleted: !prev.is_deleted }));
+  };
+
+  const handleProcessedChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    handleFieldChange("has_been_processed", event.target.checked);
+  };
+
+  const handleUrlsChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    handleFieldChange("urls", event.target.value);
+  };
+
+  const handleSnoozeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    handleFieldChange("snooze", fromDateInputValue(event.target.value));
+  };
+
+  const handleEdit = () => {
+    setIsReadOnly(false);
+    setSuccess("");
+    setError("");
+  };
+
+  const handleCancel = () => {
+    setInvoice(snapshot);
+    setIsReadOnly(true);
+    setSuccess("");
+    setError("");
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setError("");
+      const payload: InvoiceDto = {
+        ...invoice,
+        id: invoice.id || (!isNewInvoice && uuid ? uuid : invoice.id),
+      };
+      const res = await fetch("/api/setinvoice", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`Save failed: ${res.status}`);
+      const data: InvoiceDto = await res.json();
+      const merged = { ...EMPTY_INVOICE, ...data };
+      setInvoice(merged);
+      setSnapshot(merged);
+      setIsReadOnly(true);
+      setSuccess("Invoice saved.");
+      if (merged.id && uuid !== merged.id) {
+        navigate(`/invoice/${merged.id}`, { replace: true });
+      }
+    } catch (e: any) {
+      console.error(e);
+      setError(e?.message || "Failed to save invoice");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const snoozeInputValue = useMemo(() => toDateInputValue(invoice.snooze), [invoice.snooze]);
+
+  const snoozeClassName = useMemo(() => {
+    const classes = ["form-control"];
+    if (isReadOnly) classes.push("bg-light");
+    if (snoozeNeedsAttention) classes.push("border-warning", "bg-warning-subtle");
+    return classes.join(" ");
+  }, [isReadOnly, snoozeNeedsAttention]);
+
+  const effectiveUuid = invoice.id || uuid || "";
+
   return (
-    <div>
-      <h1>Invoice</h1>
-      <p>Invoice UUID: <code>{uuid}</code></p>
-      {/* TODO: fetch invoice details from /api/invoice/<uuid> */}
+    <div className="container py-4">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h1 className="h3 mb-0">Invoice</h1>
+        <div className="d-flex gap-2">
+          {isReadOnly ? (
+            <button className="btn btn-primary" type="button" onClick={handleEdit} disabled={loading}>
+              Edit
+            </button>
+          ) : (
+            <>
+              <button className="btn btn-secondary" type="button" onClick={handleCancel} disabled={saving}>
+                Cancel
+              </button>
+              <button className="btn btn-success" type="button" onClick={handleSave} disabled={saving}>
+                {saving ? "Saving..." : "Save"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      {loading && (
+        <div className="alert alert-info" role="status">Loading invoice...</div>
+      )}
+      {error && (
+        <div className="alert alert-danger" role="alert">{error}</div>
+      )}
+      {success && (
+        <div className="alert alert-success" role="status">{success}</div>
+      )}
+      <div className="mb-3">
+        <label className="form-label">📅 Date</label>
+        <div className="form-control-plaintext">{fmtDateTime(invoice.date)}</div>
+      </div>
+      <div className="mb-3">
+        <label className="form-label">✉️ Subject</label>
+        <div className="form-control-plaintext">{invoice.subject || ""}</div>
+      </div>
+      <div className="mb-3">
+        <label className="form-label" htmlFor="invoice-order-number">🛒🔢 Order Number</label>
+        <input
+          id="invoice-order-number"
+          type="text"
+          className="form-control"
+          value={invoice.order_number || ""}
+          onChange={(event) => handleFieldChange("order_number", event.target.value)}
+          disabled={isReadOnly}
+        />
+      </div>
+      <div className="mb-3">
+        <label className="form-label" htmlFor="invoice-shop-name">🛒🏠 Store Name</label>
+        <input
+          id="invoice-shop-name"
+          type="text"
+          className="form-control"
+          value={invoice.shop_name || ""}
+          onChange={(event) => handleFieldChange("shop_name", event.target.value)}
+          disabled={isReadOnly}
+        />
+      </div>
+      <div className="mb-3">
+        <label className="form-label" htmlFor="invoice-urls">🔗🔗🔗 URLs</label>
+        {isReadOnly ? (
+          <div className="d-flex flex-wrap gap-2">
+            {urlEntries.length === 0 && <span className="text-muted">No URLs</span>}
+            {urlEntries.map((url, index) => {
+              const isMail = /mail\.google\.com|gmail\.com/i.test(url);
+              const label = isMail ? "✉️" : "🔗";
+              const linkKey = `${index}-${url}`;
+              return (
+                <a key={linkKey} href={url} target="_blank" rel="noopener noreferrer" className="btn btn-sm btn-outline-secondary">
+                  {label}
+                </a>
+              );
+            })}
+          </div>
+        ) : (
+          <textarea
+            id="invoice-urls"
+            className="form-control"
+            rows={3}
+            value={invoice.urls || ""}
+            onChange={handleUrlsChange}
+          />
+        )}
+      </div>
+      <div className="mb-3">
+        <label className="form-label" htmlFor="invoice-snooze">⏰ Snooze</label>
+        <input
+          id="invoice-snooze"
+          type="date"
+          className={snoozeClassName}
+          value={snoozeInputValue}
+          onChange={handleSnoozeChange}
+          disabled={isReadOnly}
+        />
+      </div>
+      <div className="mb-3">
+        <div className="d-flex align-items-center gap-3">
+          <div className="d-flex align-items-center gap-2">
+            <label className="form-label mb-0" htmlFor="invoice-deleted-toggle">🗑️</label>
+            <button
+              id="invoice-deleted-toggle"
+              type="button"
+              className="btn btn-outline-danger"
+              onClick={handleToggleDeleted}
+              disabled={isReadOnly}
+              style={{ opacity: invoice.is_deleted ? 1 : 0.25 }}
+              aria-pressed={invoice.is_deleted}
+              aria-label={invoice.is_deleted ? "Marked deleted" : "Not deleted"}
+            >
+              🗑️
+            </button>
+          </div>
+          <div className="form-check mb-0">
+            <input
+              id="invoice-processed"
+              type="checkbox"
+              className="form-check-input"
+              checked={Boolean(invoice.has_been_processed)}
+              onChange={handleProcessedChange}
+              disabled={isReadOnly}
+            />
+            <label className="form-check-label" htmlFor="invoice-processed">Has been processed</label>
+          </div>
+        </div>
+      </div>
+      <div className="mb-3">
+        <div className="d-flex align-items-center justify-content-between">
+          <label className="form-label mb-0">HTML</label>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-primary"
+            onClick={() => setHtmlExpanded((prev) => !prev)}
+          >
+            {htmlExpanded ? "Hide" : "Show"} HTML
+          </button>
+        </div>
+        <div className={`mt-3 ${htmlExpanded ? "" : "d-none"}`}>
+          <div className="ratio ratio-16x9">
+            <iframe
+              title="Invoice HTML"
+              srcDoc={invoice.html || ""}
+              className="w-100 h-100 border"
+              sandbox="allow-same-origin"
+            />
+          </div>
+        </div>
+      </div>
+      <footer className="mt-4 text-muted small">
+        Invoice UUID: {effectiveUuid ? (
+          <a href={`/invoice/${effectiveUuid}`}>{effectiveUuid}</a>
+        ) : (
+          <span>Unavailable</span>
+        )}
+      </footer>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace the placeholder invoice page with a full view/edit form that matches the requested field ordering and emoji-labelled layout
- add read-only and edit flows with snooze highlighting, toggleable deleted/processed controls, clickable URL chips, and a collapsible HTML iframe preview
- link the footer UUID to the invoice permalink while keeping date and subject read-only

## Testing
- npm run lint *(fails: existing backend lint issues about unused imports and formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68d47fb23d00832ba668d78df23414da