### PR TITLE
Add merge association flag and maintenance stubs

### DIFF
--- a/backend/app/assoc_helper.py
+++ b/backend/app/assoc_helper.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 CONTAINMENT_BIT = 1
 RELATED_BIT = 2
 SIMILAR_BIT = 4
+MERGE_BIT = 8
 
 ALL_ASSOCIATION_BITS = (
     CONTAINMENT_BIT,
     RELATED_BIT,
     SIMILAR_BIT,
+    MERGE_BIT,
 )
 ALL_ASSOCIATION_MASK = 0
 for _bit in ALL_ASSOCIATION_BITS:
@@ -17,6 +19,7 @@ default_words = {
     CONTAINMENT_BIT: "containment",
     RELATED_BIT: "related",
     SIMILAR_BIT: "similar",
+    MERGE_BIT: "merge",
 }
 BIT_TO_WORD = dict(default_words)
 WORD_TO_BIT = {value: key for key, value in BIT_TO_WORD.items()}
@@ -24,11 +27,13 @@ BIT_TO_EMOJI_HTML_ENTITY = {
     CONTAINMENT_BIT: "&#x1F5C3;",
     RELATED_BIT: "&#x1F517;",
     SIMILAR_BIT: "&#x1F46F;",
+    MERGE_BIT: "&#x1F91D;",
 }
 BIT_TO_EMOJI_CHARACTER = {
     CONTAINMENT_BIT: "🗃️",
     RELATED_BIT: "🔗",
     SIMILAR_BIT: "👯",
+    MERGE_BIT: "🤝",
 }
 
 
@@ -61,6 +66,10 @@ def int_has_related(value: int) -> bool:
 
 def int_has_similar(value: int) -> bool:
     return bool(value & SIMILAR_BIT)
+
+
+def int_has_merge(value: int) -> bool:
+    return bool(value & MERGE_BIT)
 
 
 def collect_words_from_int(value: int) -> list[str]:

--- a/backend/services/maintenance.py
+++ b/backend/services/maintenance.py
@@ -16,7 +16,17 @@ from sqlalchemy.orm import Session
 
 from app.assoc_helper import MERGE_BIT
 from app.helpers import normalize_pg_uuid
-from app.db import get_engine
+from app.db import get_engine, get_db_item_as_dict
+from services.merge_helpers import (
+    _merge_description,
+    _merge_metatext,
+    _merge_name,
+    _merge_product_code,
+    _merge_quantity,
+    _merge_remarks,
+    _merge_source,
+    _merge_url,
+)
 from app.logging_setup import start_log
 from app.static_server import get_public_html_path
 
@@ -415,14 +425,124 @@ def merge_two_items(
     try:
         log.info("Preparing to merge items %s and %s", primary_uuid, secondary_uuid)
 
+        engine = get_engine()
+        items_table = _load_tables(engine, ("items",))["items"]
+
+        try:
+            primary_item = get_db_item_as_dict(engine, "items", primary_uuid)
+        except LookupError as exc:
+            raise ValueError(f"Primary item {primary_uuid} is missing") from exc
+
+        try:
+            secondary_item = get_db_item_as_dict(engine, "items", secondary_uuid)
+        except LookupError as exc:
+            raise ValueError(f"Secondary item {secondary_uuid} is missing") from exc
+
+        if primary_item.get("is_deleted"):
+            raise ValueError(f"Primary item {primary_uuid} is already deleted")
+
+        if secondary_item.get("is_deleted"):
+            raise ValueError(f"Secondary item {secondary_uuid} is already deleted")
+
+        updates: Dict[str, object] = {}
+
+        primary_creation = primary_item.get("date_creation")
+        secondary_creation = secondary_item.get("date_creation")
+
+        name_value = _merge_name(
+            primary_item.get("name", ""),
+            secondary_item.get("name", ""),
+            primary_created=primary_creation,
+            secondary_created=secondary_creation,
+        )
+        if name_value != primary_item.get("name"):
+            updates["name"] = name_value
+
+        description_value = _merge_description(
+            primary_item.get("description", ""),
+            secondary_item.get("description", ""),
+            primary_created=primary_creation,
+            secondary_created=secondary_creation,
+        )
+        if description_value != primary_item.get("description"):
+            updates["description"] = description_value
+
+        remarks_value = _merge_remarks(
+            primary_item.get("remarks", ""),
+            secondary_item.get("remarks", ""),
+            primary_created=primary_creation,
+            secondary_created=secondary_creation,
+        )
+        if remarks_value != primary_item.get("remarks"):
+            updates["remarks"] = remarks_value
+
+        text_mergers = (
+            ("quantity", _merge_quantity),
+            ("product_code", _merge_product_code),
+            ("url", _merge_url),
+            ("source", _merge_source),
+        )
+
+        for column, merger in text_mergers:
+            merged_value = merger(primary_item.get(column, ""), secondary_item.get(column, ""))
+            if merged_value != primary_item.get(column):
+                updates[column] = merged_value
+
+        metatext_value = _merge_metatext(primary_item.get("metatext", ""), secondary_item.get("metatext", ""))
+        if metatext_value != primary_item.get("metatext"):
+            updates["metatext"] = metatext_value
+
+        boolean_fields = (
+            "is_container",
+            "is_collection",
+            "is_large",
+            "is_small",
+            "is_fixed_location",
+            "is_consumable",
+        )
+
+        for field in boolean_fields:
+            combined_flag = bool(primary_item.get(field)) or bool(secondary_item.get(field))
+            if combined_flag != bool(primary_item.get(field)):
+                updates[field] = combined_flag
+
+        date_fields = (
+            "date_purchased",
+            "date_reminder",
+            "date_last_modified",
+        )
+
+        for field in date_fields:
+            dates = [primary_item.get(field), secondary_item.get(field)]
+            recent_dates = [value for value in dates if value is not None]
+            if not recent_dates:
+                continue
+            newest = max(recent_dates)
+            if newest != primary_item.get(field):
+                updates[field] = newest
+
+        if not updates:
+            log.info("No field updates were necessary when merging %s into %s", secondary_uuid, primary_uuid)
+
         with transaction_ctx:
-            # TODO: Confirm that both item rows exist and select which one should remain.
+            if updates:
+                executor.execute(
+                    update(items_table)
+                    .where(items_table.c.id == primary_uuid)
+                    .values(**updates)
+                )
+
+            executor.execute(
+                update(items_table)
+                .where(items_table.c.id == secondary_uuid)
+                .values(is_deleted=True)
+            )
+
             # TODO: Consolidate descriptive fields, notes, and metadata into the surviving item.
             # TODO: Reassign tags, categories, and other relationships from the secondary item.
             # TODO: Merge associated images while avoiding duplicate entries in the item_images table.
             # TODO: Transfer inventory, invoice links, or other domain-specific associations.
             # TODO: Remove or update the initiating merge row from the relationships table.
-            # TODO: Soft-delete or archive the secondary item once all data has been transferred.
             # TODO: Trigger any indexing or cache refresh required after the merge completes.
             # TODO: Record an audit trail summarizing the merge for future reference.
     finally:
@@ -438,6 +558,7 @@ def process_pending_merges(
 
     processed_pairs = 0
     seen_pairs: Set[frozenset[uuid.UUID]] = set()
+    engine = get_engine()
 
     try:
         merge_clause = relationships_table.c.assoc_type.op("&")(MERGE_BIT) != 0
@@ -482,6 +603,26 @@ def process_pending_merges(
             seen_pairs.add(pair_key)
 
             try:
+                secondary_snapshot = get_db_item_as_dict(engine, "items", right_uuid)
+            except LookupError:
+                log.warning("Skipping merge candidate with missing secondary item: %s", right_uuid)
+                continue
+
+            if secondary_snapshot.get("is_deleted"):
+                log.info("Secondary item %s is deleted; skipping merge", right_uuid)
+                continue
+
+            try:
+                primary_snapshot = get_db_item_as_dict(engine, "items", left_uuid)
+            except LookupError:
+                log.warning("Skipping merge candidate with missing primary item: %s", left_uuid)
+                continue
+
+            if primary_snapshot.get("is_deleted"):
+                log.info("Primary item %s is deleted; skipping merge", left_uuid)
+                continue
+
+            try:
                 merge_two_items(
                     db=executor,
                     first_item_uuid=left_uuid,
@@ -498,6 +639,7 @@ def process_pending_merges(
         return processed_pairs
     finally:
         cleanup()
+
 
 def main():
     # Initialize logger using your existing setup

--- a/backend/services/maintenance.py
+++ b/backend/services/maintenance.py
@@ -4,16 +4,17 @@
 import logging
 import time
 import uuid
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Set, Union
+from typing import Callable, Dict, List, Optional, Sequence, Set, Union
 
 from dotenv import load_dotenv
 from sqlalchemy import MetaData, Table, delete, or_, select, update
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.orm import Session
 
+from app.assoc_helper import MERGE_BIT
 from app.helpers import normalize_pg_uuid
 from app.db import get_engine
 from app.logging_setup import start_log
@@ -36,6 +37,65 @@ def _load_tables(engine: Engine, table_names: Sequence[str]) -> Dict[str, Table]
         tables[name] = Table(name, metadata, autoload_with=engine)
         log.debug("Reflected table %s", name)
     return tables
+
+
+def _prepare_relationship_context(
+    db: Optional[Union[Engine, Connection, Session]] = None,
+) -> tuple[
+    Union[Connection, Session],
+    Table,
+    Callable[[], None],
+    AbstractContextManager[object],
+]:
+    """Resolve a database executor and reflected relationships table.
+
+    Returns a tuple of ``(executor, relationships_table, cleanup, transaction_ctx)``
+    where ``executor`` is either a :class:`~sqlalchemy.engine.Connection` or
+    :class:`~sqlalchemy.orm.Session`, ``relationships_table`` is the reflected
+    SQLAlchemy table, ``cleanup`` is a callable that will close any temporary
+    connection created by this helper, and ``transaction_ctx`` is a context
+    manager suitable for wrapping write operations.
+    """
+
+    session: Optional[Session] = None
+    connection: Optional[Connection] = None
+    should_close_connection = False
+
+    if isinstance(db, Session):
+        session = db
+    elif isinstance(db, Connection):
+        connection = db
+    elif isinstance(db, Engine) or db is None:
+        engine = db if isinstance(db, Engine) else get_engine()
+        connection = engine.connect()
+        should_close_connection = True
+    else:
+        raise TypeError("db must be an Engine, Connection, Session, or None")
+
+    executor: Optional[Union[Connection, Session]] = session if session is not None else connection
+    if executor is None:
+        raise RuntimeError("Unable to determine database execution context")
+
+    if session is not None:
+        transaction_ctx: AbstractContextManager[object] = (
+            session.begin() if not session.in_transaction() else nullcontext()
+        )
+        bind = session.get_bind()
+    else:
+        assert connection is not None  # nosec - validated above
+        transaction_ctx = (
+            connection.begin() if not connection.in_transaction() else nullcontext()
+        )
+        bind = connection.engine
+
+    metadata = MetaData()
+    relationships_table = Table("relationships", metadata, autoload_with=bind)
+
+    def cleanup() -> None:
+        if should_close_connection and connection is not None:
+            connection.close()
+
+    return executor, relationships_table, cleanup, transaction_ctx
 
 
 def prune_deleted() -> Dict[str, int]:
@@ -252,95 +312,68 @@ def neaten_relationship(
         except (TypeError, ValueError) as exc:
             raise ValueError("item_uuid must be a valid UUID value") from exc
 
-    session: Optional[Session] = None
-    connection: Optional[Connection] = None
-    should_close_connection = False
+    executor, _, cleanup, transaction_ctx = _prepare_relationship_context(db)
 
-    if isinstance(db, Session):
-        session = db
-    elif isinstance(db, Connection):
-        connection = db
-    elif isinstance(db, Engine) or db is None:
-        engine = db if isinstance(db, Engine) else get_engine()
-        connection = engine.connect()
-        should_close_connection = True
-    else:
-        raise TypeError("db must be an Engine, Connection, Session, or None")
-
-    executor = session if session is not None else connection
-    if executor is None:
-        raise RuntimeError("Unable to determine database execution context")
-
-    if session is not None:
-        transaction_ctx = session.begin() if not session.in_transaction() else nullcontext()
-        bind = session.get_bind()
-    else:
-        assert connection is not None  # nosec - validated above
-        transaction_ctx = connection.begin() if not connection.in_transaction() else nullcontext()
-        bind = connection.engine
-
-    metadata = MetaData()
-    relationships_table = Table("relationships", metadata, autoload_with=bind)
-
-    stmt = select(
-        relationships_table.c.id,
-        relationships_table.c.item_id,
-        relationships_table.c.assoc_id,
-        relationships_table.c.assoc_type,
-    )
-    if target_uuid is not None:
-        stmt = stmt.where(
-            or_(
-                relationships_table.c.item_id == target_uuid,
-                relationships_table.c.assoc_id == target_uuid,
-            )
-        )
-
-    rows = executor.execute(stmt).mappings().all()
-
-    groups: Dict[tuple[str, str], List[dict]] = {}
-    for row in rows:
-        left = str(row["item_id"])
-        right = str(row["assoc_id"])
-        if left == right:
-            continue
-        key = (left, right) if left <= right else (right, left)
-        groups.setdefault(key, []).append(dict(row))
-
+    rows: List[dict] = []
     updates: List[tuple[uuid.UUID, int]] = []
     deletions: List[uuid.UUID] = []
     merged_pairs = 0
 
-    for entries in groups.values():
-        if len(entries) <= 1:
-            continue
-        merged_pairs += 1
-        entries.sort(key=lambda data: str(data["id"]))
-        primary = entries[0]
-        combined_type = 0
-        for entry in entries:
-            combined_type |= int(entry["assoc_type"] or 0)
-        if combined_type != int(primary["assoc_type"] or 0):
-            updates.append((primary["id"], combined_type))
-        for entry in entries[1:]:
-            deletions.append(entry["id"])
-
-    with transaction_ctx:
-        for row_id, combined in updates:
-            executor.execute(
-                update(relationships_table)
-                .where(relationships_table.c.id == row_id)
-                .values(assoc_type=combined)
-            )
-        if deletions:
-            executor.execute(
-                delete(relationships_table).where(
-                    relationships_table.c.id.in_(tuple(deletions))
+    try:
+        stmt = select(
+            relationships_table.c.id,
+            relationships_table.c.item_id,
+            relationships_table.c.assoc_id,
+            relationships_table.c.assoc_type,
+        )
+        if target_uuid is not None:
+            stmt = stmt.where(
+                or_(
+                    relationships_table.c.item_id == target_uuid,
+                    relationships_table.c.assoc_id == target_uuid,
                 )
             )
 
-    if should_close_connection and connection is not None:
-        connection.close()
+        rows = executor.execute(stmt).mappings().all()
+
+        groups: Dict[tuple[str, str], List[dict]] = {}
+        for row in rows:
+            left = str(row["item_id"])
+            right = str(row["assoc_id"])
+            if left == right:
+                continue
+            key = (left, right) if left <= right else (right, left)
+            groups.setdefault(key, []).append(dict(row))
+
+        for entries in groups.values():
+            if len(entries) <= 1:
+                continue
+            merged_pairs += 1
+            entries.sort(key=lambda data: str(data["id"]))
+            primary = entries[0]
+            combined_type = 0
+            for entry in entries:
+                combined_type |= int(entry["assoc_type"] or 0)
+            if combined_type != int(primary["assoc_type"] or 0):
+                updates.append((primary["id"], combined_type))
+            for entry in entries[1:]:
+                deletions.append(entry["id"])
+
+        with transaction_ctx:
+            for row_id, combined in updates:
+                executor.execute(
+                    update(relationships_table)
+                    .where(relationships_table.c.id == row_id)
+                    .values(assoc_type=combined)
+                )
+            if deletions:
+                executor.execute(
+                    delete(relationships_table).where(
+                        relationships_table.c.id.in_(tuple(deletions))
+                    )
+                )
+    finally:
+        cleanup()
 
     return {
         "rows_examined": len(rows),
@@ -349,6 +382,122 @@ def neaten_relationship(
         "rows_deleted": len(deletions),
     }
 
+
+def merge_two_items(
+    db: Optional[Union[Engine, Connection, Session]] = None,
+    first_item_uuid: Optional[Union[str, uuid.UUID]] = None,
+    second_item_uuid: Optional[Union[str, uuid.UUID]] = None,
+) -> None:
+    """Merge two items that have been flagged with the merge association."""
+
+    if first_item_uuid is None or second_item_uuid is None:
+        raise ValueError("Both item UUIDs must be provided for a merge operation")
+
+    try:
+        primary_uuid = (
+            first_item_uuid
+            if isinstance(first_item_uuid, uuid.UUID)
+            else uuid.UUID(normalize_pg_uuid(first_item_uuid))
+        )
+        secondary_uuid = (
+            second_item_uuid
+            if isinstance(second_item_uuid, uuid.UUID)
+            else uuid.UUID(normalize_pg_uuid(second_item_uuid))
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Item UUIDs must be valid UUID values") from exc
+
+    if primary_uuid == secondary_uuid:
+        raise ValueError("Cannot merge an item with itself")
+
+    executor, _relationships_table, cleanup, transaction_ctx = _prepare_relationship_context(db)
+
+    try:
+        log.info("Preparing to merge items %s and %s", primary_uuid, secondary_uuid)
+
+        with transaction_ctx:
+            # TODO: Confirm that both item rows exist and select which one should remain.
+            # TODO: Consolidate descriptive fields, notes, and metadata into the surviving item.
+            # TODO: Reassign tags, categories, and other relationships from the secondary item.
+            # TODO: Merge associated images while avoiding duplicate entries in the item_images table.
+            # TODO: Transfer inventory, invoice links, or other domain-specific associations.
+            # TODO: Remove or update the initiating merge row from the relationships table.
+            # TODO: Soft-delete or archive the secondary item once all data has been transferred.
+            # TODO: Trigger any indexing or cache refresh required after the merge completes.
+            # TODO: Record an audit trail summarizing the merge for future reference.
+    finally:
+        cleanup()
+
+
+def process_pending_merges(
+    db: Optional[Union[Engine, Connection, Session]] = None,
+) -> int:
+    """Scan for merge associations and invoke :func:`merge_two_items` for each."""
+
+    executor, relationships_table, cleanup, _transaction_ctx = _prepare_relationship_context(db)
+
+    processed_pairs = 0
+    seen_pairs: Set[frozenset[uuid.UUID]] = set()
+
+    try:
+        merge_clause = relationships_table.c.assoc_type.op("&")(MERGE_BIT) != 0
+        stmt = select(
+            relationships_table.c.item_id,
+            relationships_table.c.assoc_id,
+            relationships_table.c.assoc_type,
+        ).where(merge_clause)
+
+        rows = executor.execute(stmt).mappings().all()
+        log.info("Found %s merge relationship candidates", len(rows))
+
+        for row in rows:
+            left_raw = row.get("item_id")
+            right_raw = row.get("assoc_id")
+            if left_raw is None or right_raw is None:
+                log.warning("Skipping merge candidate with missing item identifiers: %s", row)
+                continue
+
+            try:
+                left_uuid = (
+                    left_raw
+                    if isinstance(left_raw, uuid.UUID)
+                    else uuid.UUID(normalize_pg_uuid(str(left_raw)))
+                )
+                right_uuid = (
+                    right_raw
+                    if isinstance(right_raw, uuid.UUID)
+                    else uuid.UUID(normalize_pg_uuid(str(right_raw)))
+                )
+            except (TypeError, ValueError):
+                log.exception("Encountered merge row with invalid UUIDs: %s", row)
+                continue
+
+            if left_uuid == right_uuid:
+                log.warning("Skipping self-referential merge candidate for %s", left_uuid)
+                continue
+
+            pair_key = frozenset({left_uuid, right_uuid})
+            if pair_key in seen_pairs:
+                continue
+            seen_pairs.add(pair_key)
+
+            try:
+                merge_two_items(
+                    db=executor,
+                    first_item_uuid=left_uuid,
+                    second_item_uuid=right_uuid,
+                )
+                processed_pairs += 1
+            except Exception:
+                log.exception(
+                    "Failed to merge items %s and %s flagged for merge",
+                    left_uuid,
+                    right_uuid,
+                )
+
+        return processed_pairs
+    finally:
+        cleanup()
 
 def main():
     # Initialize logger using your existing setup

--- a/backend/services/merge_helpers.py
+++ b/backend/services/merge_helpers.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Optional, Tuple, Any
+
+SEPARATOR = ";"
+
+SECTION_BREAK = "\r\n\r\n#####\r\n\r\n"
+
+def _normalize_datetime(candidate: Any) -> Optional[datetime]:
+    if isinstance(candidate, datetime):
+        return candidate
+    if isinstance(candidate, str):
+        text = candidate.strip()
+        if not text:
+            return None
+        try:
+            if text.endswith("Z"):
+                text = f"{text[:-1]}+00:00"
+            return datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    return None
+
+def _prioritized_values(
+    primary_value: str,
+    secondary_value: str,
+    primary_created: Optional[Any],
+    secondary_created: Optional[Any],
+) -> Tuple[str, str]:
+    primary_ts = _normalize_datetime(primary_created)
+    secondary_ts = _normalize_datetime(secondary_created)
+    if primary_ts and secondary_ts:
+        if primary_ts <= secondary_ts:
+            return primary_value, secondary_value
+        return secondary_value, primary_value
+    if primary_ts and not secondary_ts:
+        return primary_value, secondary_value
+    if secondary_ts and not primary_ts:
+        return secondary_value, primary_value
+    return primary_value, secondary_value
+
+def _merge_name(
+    primary: str,
+    secondary: str,
+    *,
+    primary_created: Optional[Any] = None,
+    secondary_created: Optional[Any] = None,
+) -> str:
+    primary_value = (primary or "").strip()
+    secondary_value = (secondary or "").strip()
+    if not primary_value and secondary_value:
+        return secondary_value
+    if primary_value and not secondary_value:
+        return primary_value
+    if not primary_value and not secondary_value:
+        return ""
+    if primary_value == secondary_value:
+        return primary_value
+    prioritized, alternate = _prioritized_values(
+        primary_value,
+        secondary_value,
+        primary_created,
+        secondary_created,
+    )
+    return prioritized or alternate
+
+def _merge_description(
+    primary: str,
+    secondary: str,
+    *,
+    primary_created: Optional[Any] = None,
+    secondary_created: Optional[Any] = None,
+) -> str:
+    primary_value = (primary or "").strip()
+    secondary_value = (secondary or "").strip()
+    if not primary_value and secondary_value:
+        return secondary_value
+    if primary_value and not secondary_value:
+        return primary_value
+    if not primary_value and not secondary_value:
+        return ""
+    if primary_value == secondary_value:
+        return primary_value
+    first, second = _prioritized_values(
+        primary_value,
+        secondary_value,
+        primary_created,
+        secondary_created,
+    )
+    ordered = [value for value in (first, second) if value]
+    return SECTION_BREAK.join(ordered)
+
+def _merge_remarks(
+    primary: str,
+    secondary: str,
+    *,
+    primary_created: Optional[Any] = None,
+    secondary_created: Optional[Any] = None,
+) -> str:
+    primary_value = (primary or "").strip()
+    secondary_value = (secondary or "").strip()
+    if not primary_value and secondary_value:
+        return secondary_value
+    if primary_value and not secondary_value:
+        return primary_value
+    if not primary_value and not secondary_value:
+        return ""
+    if primary_value == secondary_value:
+        return primary_value
+    first, second = _prioritized_values(
+        primary_value,
+        secondary_value,
+        primary_created,
+        secondary_created,
+    )
+    ordered = [value for value in (first, second) if value]
+    return SECTION_BREAK.join(ordered)
+
+def _deduplicate(values: Iterable[str]) -> List[str]:
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        if not value:
+            continue
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        ordered.append(cleaned)
+    return ordered
+
+def _merge_with_separator(primary: str, secondary: str) -> str:
+    deduped = _deduplicate([primary, secondary])
+    return SEPARATOR.join(deduped)
+
+def _merge_product_code(primary: str, secondary: str) -> str:
+    return _merge_with_separator(primary, secondary)
+
+def _merge_url(primary: str, secondary: str) -> str:
+    return _merge_with_separator(primary, secondary)
+
+def _merge_source(primary: str, secondary: str) -> str:
+    return _merge_with_separator(primary, secondary)
+
+def _merge_quantity(primary: str, secondary: str) -> str:
+    return _merge_with_separator(primary, secondary)
+
+def _merge_metatext(primary: str, secondary: str) -> str:
+    words = []
+    words.extend((primary or "").split())
+    words.extend((secondary or "").split())
+    unique_words = _deduplicate(words)
+    return " ".join(unique_words)
+
+__all__ = [
+    "_merge_name",
+    "_merge_description",
+    "_merge_remarks",
+    "_merge_product_code",
+    "_merge_url",
+    "_merge_source",
+    "_merge_quantity",
+    "_merge_metatext",
+]

--- a/frontend/src/app/components/SearchPanel.tsx
+++ b/frontend/src/app/components/SearchPanel.tsx
@@ -9,6 +9,7 @@ import {
   ALL_ASSOCIATION_BITS,
   ALL_ASSOCIATION_MASK,
   CONTAINMENT_BIT,
+  MERGE_BIT,
   RELATED_BIT,
   SIMILAR_BIT,
   bit_to_emoji_character,
@@ -16,6 +17,7 @@ import {
   collect_emoji_characters_from_int,
   collect_words_from_int,
   int_has_containment,
+  int_has_merge,
   int_has_related,
   int_has_similar,
 } from "../helpers/assocHelper";
@@ -473,6 +475,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
   const containmentChecked = int_has_containment(associationBits);
   const relatedChecked = int_has_related(associationBits);
   const similarChecked = int_has_similar(associationBits);
+  const mergeChecked = int_has_merge(associationBits);
 
   const toggleCheckbox = useCallback(
     (row: SearchRow, checked: boolean) => {
@@ -1065,6 +1068,8 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
                         ? relatedChecked
                         : bit === SIMILAR_BIT
                         ? similarChecked
+                        : bit === MERGE_BIT
+                        ? mergeChecked
                         : (associationBits & bit) === bit;
                     const emoji = bit_to_emoji_character(bit);
                     const label = bit_to_word(bit) || "association";

--- a/frontend/src/app/helpers/assocHelper.tsx
+++ b/frontend/src/app/helpers/assocHelper.tsx
@@ -1,11 +1,13 @@
 export const CONTAINMENT_BIT = 1;
 export const RELATED_BIT = 2;
 export const SIMILAR_BIT = 4;
+export const MERGE_BIT = 8;
 
 export const ALL_ASSOCIATION_BITS = [
   CONTAINMENT_BIT,
   RELATED_BIT,
   SIMILAR_BIT,
+  MERGE_BIT,
 ] as const;
 export const ALL_ASSOCIATION_MASK = ALL_ASSOCIATION_BITS.reduce(
   (mask, bit) => mask | bit,
@@ -16,6 +18,7 @@ const BIT_TO_WORD: Record<number, string> = {
   [CONTAINMENT_BIT]: "containment",
   [RELATED_BIT]: "related",
   [SIMILAR_BIT]: "similar",
+  [MERGE_BIT]: "merge",
 };
 const WORD_TO_BIT: Record<string, number> = Object.entries(BIT_TO_WORD).reduce<
   Record<string, number>
@@ -28,11 +31,13 @@ const BIT_TO_EMOJI_HTML_ENTITY: Record<number, string> = {
   [CONTAINMENT_BIT]: "&#x1F5C3;",
   [RELATED_BIT]: "&#x1F517;",
   [SIMILAR_BIT]: "&#x1F46F;",
+  [MERGE_BIT]: "&#x1F91D;",
 };
 const BIT_TO_EMOJI_CHARACTER: Record<number, string> = {
   [CONTAINMENT_BIT]: "🗃️",
   [RELATED_BIT]: "🔗",
   [SIMILAR_BIT]: "👯",
+  [MERGE_BIT]: "🤝",
 };
 
 export function bit_to_word(bit: number): string {
@@ -65,6 +70,10 @@ export function int_has_related(value: number): boolean {
 
 export function int_has_similar(value: number): boolean {
   return (value & SIMILAR_BIT) === SIMILAR_BIT;
+}
+
+export function int_has_merge(value: number): boolean {
+  return (value & MERGE_BIT) === MERGE_BIT;
 }
 
 export function collect_words_from_int(value: number): string[] {


### PR DESCRIPTION
## Summary
- add the new merge association bit and emoji helpers to the backend and frontend utilities
- expose the merge toggle in the SearchPanel footer controls
- refactor relationship maintenance helpers and scaffold merge processing stubs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d484e9a01c832bb83a2cbf8f0fec53