### PR TITLE
Add ledger actions for email checks and invoice uploads

### DIFF
--- a/backend/app/invoice_handlers.py
+++ b/backend/app/invoice_handlers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from flask import Blueprint, jsonify, request
+from werkzeug.datastructures import FileStorage
+
+from .user_login import login_required
+
+bp = Blueprint("invoice_handlers", __name__, url_prefix="/api")
+
+
+def _ingest_invoice_file(file_storage: FileStorage) -> Dict[str, Any]:
+    """Prepare metadata for a single uploaded invoice/email file.
+
+    TODO: Parse MIME and HTML structures similar to backend/automation/gmail_proc.py.
+    TODO: Reuse backend/automation/order_num_extract.py heuristics to derive order identifiers.
+    TODO: Map parsed fields into the invoice tables defined in backend/schemas/schema.sql.
+    """
+    return {
+        "filename": file_storage.filename or "",
+        "status": "pending",
+        "notes": "TODO: implement invoice ingestion pipeline.",
+    }
+
+
+@bp.route("/checkemail", methods=["POST"])
+@login_required
+def check_email() -> Any:
+    """Kick off background processing to pull invoices from the mailbox.
+
+    TODO: Use backend/automation/gmail_proc.py to connect to Gmail, download messages, and attachments.
+    TODO: Run backend/automation/order_num_extract.py routines to enrich invoice metadata.
+    TODO: Upsert invoice rows plus email state into the tables defined in backend/schemas/schema.sql.
+    """
+    return jsonify(
+        {
+            "ok": True,
+            "message": "Email check accepted. TODO: wire up mailbox processing pipeline.",
+        }
+    )
+
+
+@bp.route("/invoiceupload", methods=["POST"])
+@login_required
+def invoice_upload() -> Any:
+    """Accept uploaded invoice files and process them like inbound emails.
+
+    TODO: Support bulk uploads by streaming each file into the same pipeline used for Gmail messages.
+    TODO: Capture missing metadata (sender, subject, timestamps) with sensible defaults when absent.
+    TODO: Persist invoice and attachment records according to backend/schemas/schema.sql.
+    """
+    files = request.files.getlist("files") or request.files.getlist("file")
+    if not files:
+        return jsonify({"error": "No invoice files provided."}), 400
+
+    processed: List[Dict[str, Any]] = []
+    for storage in files:
+        if not storage:
+            continue
+        processed.append(_ingest_invoice_file(storage))
+        # TODO: Persist each result just like a processed Gmail message would be saved.
+
+    return jsonify(
+        {
+            "ok": True,
+            "processed": processed,
+            "message": "Invoice upload accepted. TODO: persist invoices and metadata.",
+        }
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .errors import register_error_handlers
 from .static_server import bp_overlay, get_public_html_path
 from .imagehandler import bp_image
 from .user_login import bp as bp_auth
+from .invoice_handlers import bp as bp_invoice
 from .items import bp as bp_items
 from .maint import bp as bp_maint
 from .search import bp as bp_search
@@ -43,6 +44,7 @@ def create_app():
     app.register_blueprint(bp_overlay)
     app.register_blueprint(bp_image)
     app.register_blueprint(bp_search)
+    app.register_blueprint(bp_invoice)
     app.register_blueprint(bp_items)
     app.register_blueprint(bp_maint)
 

--- a/frontend/src/pages/LedgerSearchPage.tsx
+++ b/frontend/src/pages/LedgerSearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import SearchPanel from "../app/components/SearchPanel";
@@ -6,16 +6,199 @@ import SearchPanel from "../app/components/SearchPanel";
 const LedgerSearchPage: React.FC = () => {
   const { xyz } = useParams<{ xyz?: string }>();
   const prefilled = useMemo(() => (xyz ? decodeURIComponent(xyz) : ""), [xyz]);
+  const [searchPrefill, setSearchPrefill] = useState(prefilled);
+  const [checkEmailBusy, setCheckEmailBusy] = useState(false);
+  const [uploadBusy, setUploadBusy] = useState(false);
+  const [modalMessage, setModalMessage] = useState<
+    | {
+        title: string;
+        body: string;
+      }
+    | null
+  >(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setSearchPrefill(prefilled);
+  }, [prefilled]);
+
+  const showModal = (title: string, body: string) => {
+    setModalMessage({ title, body });
+  };
+
+  const handleCheckEmail = async () => {
+    if (checkEmailBusy) {
+      return;
+    }
+    setCheckEmailBusy(true);
+    try {
+      const response = await fetch("/api/checkemail", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      let payload: any = null;
+      try {
+        payload = await response.json();
+      } catch (error) {
+        payload = null;
+      }
+      if (!response.ok) {
+        const message =
+          (payload && (payload.error || payload.message)) ||
+          response.statusText ||
+          "Failed to contact email checker.";
+        throw new Error(message);
+      }
+      setSearchPrefill("* ?!has_been_processed \\bydate \\orderrev");
+      const message =
+        (payload && (payload.message || payload.detail)) ||
+        "Email check completed successfully.";
+      showModal("Email check complete", message);
+    } catch (error: any) {
+      const message = error?.message || "Email check failed.";
+      showModal("Email check failed", message);
+    } finally {
+      setCheckEmailBusy(false);
+    }
+  };
+
+  const handleFileSelection = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = event.target.files;
+    if (!files) {
+      setSelectedFiles([]);
+      return;
+    }
+    setSelectedFiles(Array.from(files));
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFiles.length || uploadBusy) {
+      return;
+    }
+    setUploadBusy(true);
+    try {
+      const formData = new FormData();
+      selectedFiles.forEach((file) => {
+        formData.append("files", file);
+      });
+      const response = await fetch("/api/invoiceupload", {
+        method: "POST",
+        body: formData,
+      });
+      let payload: any = null;
+      try {
+        payload = await response.json();
+      } catch (error) {
+        payload = null;
+      }
+      if (!response.ok) {
+        const message =
+          (payload && (payload.error || payload.message)) ||
+          response.statusText ||
+          "Invoice upload failed.";
+        throw new Error(message);
+      }
+      setSearchPrefill("* ?!has_been_processed \\bydate \\orderrev");
+      const message =
+        (payload && (payload.message || payload.detail)) ||
+        "Invoices uploaded successfully.";
+      showModal("Invoice upload complete", message);
+      setSelectedFiles([]);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    } catch (error: any) {
+      const message = error?.message || "Invoice upload failed.";
+      showModal("Invoice upload failed", message);
+    } finally {
+      setUploadBusy(false);
+    }
+  };
+
+  const renderBusyIndicator = (message: string) => (
+    <div className="d-flex align-items-center gap-2 mt-2" role="status">
+      <div className="spinner-border spinner-border-sm" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
 
   return (
     <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
       <h1 className="h3 mb-4">Search Invoices</h1>
       <SearchPanel
         displayedTitle="Invoices"
-        prefilledQuery={prefilled}
+        prefilledQuery={searchPrefill}
         tableName="invoices"
         allowDelete
       />
+
+      <div className="mt-5">
+        <h2 className="h5">Check email for invoices</h2>
+        <p className="text-muted">
+          Trigger the email processor to pull the latest invoices from the mailbox.
+        </p>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleCheckEmail}
+          disabled={checkEmailBusy}
+        >
+          {checkEmailBusy ? "Checking…" : "Check email"}
+        </button>
+        {checkEmailBusy && renderBusyIndicator("Checking mailbox for invoices…")}
+      </div>
+
+      <div className="mt-4">
+        <h2 className="h5">Upload invoice files</h2>
+        <p className="text-muted">
+          Upload archived email files (.mht, .mhtml, .htm, .html) to import invoices directly.
+        </p>
+        <div className="d-flex flex-column flex-sm-row align-items-start gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="form-control"
+            accept=".mht,.mhtm,.mhtml,.htm,.html"
+            multiple
+            onChange={handleFileSelection}
+            disabled={uploadBusy}
+          />
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={handleUpload}
+            disabled={uploadBusy || !selectedFiles.length}
+          >
+            {uploadBusy ? "Uploading…" : "Upload"}
+          </button>
+        </div>
+        {uploadBusy && renderBusyIndicator("Uploading invoices…")}
+      </div>
+
+      {modalMessage && (
+        <div
+          className="position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center"
+          style={{ backgroundColor: "rgba(0, 0, 0, 0.35)", zIndex: 1050 }}
+        >
+          <div className="bg-white border rounded-3 shadow p-4" role="dialog" aria-modal="true">
+            <h3 className="h5">{modalMessage.title}</h3>
+            <p className="mb-4">{modalMessage.body}</p>
+            <div className="text-end">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => setModalMessage(null)}
+              >
+                OK
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add check-email and invoice upload actions to the ledger search page with busy indicators and modal feedback
- provide Flask endpoints that stub out the mailbox polling and invoice upload flows with TODOs pointing to related modules
- register the invoice handlers blueprint with the app factory so the new routes are exposed

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d4d0b8aeec832b8677d0cfc8d7e3d6