### PR TITLE
Allow alpha-numeric order tokens

### DIFF
--- a/backend/automation/order_num_extract.py
+++ b/backend/automation/order_num_extract.py
@@ -33,13 +33,15 @@ KEYWORD_PATTERNS = [
 KEYWORD_RE = re.compile(r"(?i)\b(?:" + "|".join(KEYWORD_PATTERNS) + r")\b")
 
 # Strict token (general case): 6–40 chars, alnum with internal - _
-#STRICT_TOKEN_RE = r"[A-Z0-9](?:[A-Z0-9\-_]{4,38})[A-Z0-9]"
-STRICT_TOKEN_RE = r"[0-9](?:[0-9\-_]{4,38})[0-9]"
+STRICT_NUMERIC_TOKEN_RE = r"[0-9](?:[0-9\-_]{4,38})[0-9]"
+STRICT_ALNUM_TOKEN_RE = r"(?=[A-Z0-9\-_]*[A-Z])(?=[A-Z0-9\-_]*[0-9])[A-Z0-9](?:[A-Z0-9\-_]{4,38})[A-Z0-9]"
+STRICT_TOKEN_RE = rf"(?:{STRICT_NUMERIC_TOKEN_RE}|{STRICT_ALNUM_TOKEN_RE})"
 
 # Short IDs for strongly-cued forms like "Order No. 1135" or "Invoice num: A12B3"
 # 3–12 chars, allow hyphenated groups
-#SHORT_ID_RE = r"[A-Z0-9]{3,12}(?:-[A-Z0-9]{2,12}){0,3}"
-SHORT_ID_RE = r"[0-9]{3,12}(?:-[0-9]{2,12}){0,3}"
+SHORT_NUMERIC_ID_RE = r"[0-9]{3,12}(?:-[0-9]{2,12}){0,3}"
+SHORT_ALNUM_ID_RE = r"(?=[A-Z0-9-]*[A-Z])(?=[A-Z0-9-]*[0-9])[A-Z0-9]{3,12}(?:-[A-Z0-9]{2,12}){0,3}"
+SHORT_ID_RE = rf"(?:{SHORT_NUMERIC_ID_RE}|{SHORT_ALNUM_ID_RE})"
 
 # Cues immediately before a short ID:
 # - "#"
@@ -57,7 +59,9 @@ SHORT_CUE_RE = (
 # Words we want to avoid drifting into after the keyword
 AVOID_WORDS = r"(?:date|placed|total|status|shipment|shipped|tracking)"
 
-TOKEN_RE = r"[0-9](?:[0-9\-_]{2,38})[0-9]"
+GENERIC_NUMERIC_TOKEN_RE = r"[0-9](?:[0-9\-_]{2,38})[0-9]"
+GENERIC_ALNUM_TOKEN_RE = r"(?=[A-Z0-9\-_]*[A-Z])(?=[A-Z0-9\-_]*[0-9])[A-Z0-9](?:[A-Z0-9\-_]{2,38})[A-Z0-9]"
+TOKEN_RE = rf"(?:{GENERIC_NUMERIC_TOKEN_RE}|{GENERIC_ALNUM_TOKEN_RE})"
 TOKEN = re.compile(r"(?i)" + TOKEN_RE)
 
 KEYWORD_THEN_ID = re.compile(


### PR DESCRIPTION
## Summary
- allow order number extraction logic to match alphanumeric identifiers while still accepting numeric ones
- extend strict, short, and generic token patterns with letter-digit heuristics to avoid plain English words

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d4d1693a34832b87304f8b313e0e29