### PR TITLE
Implement Gmail check email handler

### DIFF
--- a/backend/app/invoice_handlers.py
+++ b/backend/app/invoice_handlers.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import date, datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import text
+from werkzeug.datastructures import FileStorage
+
+from automation.gmail_proc import (
+    extract_text_content,
+    get_full_message,
+    gmail_date_x_days_query,
+    list_message_ids,
+)
+from automation.order_num_extract import extract_order_number, extract_order_number_and_url
+from app.db import get_engine, update_db_row_by_dict
+
+from .user_login import login_required
+
+bp = Blueprint("invoice_handlers", __name__, url_prefix="/api")
+
+log = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SECRETS_PATH = REPO_ROOT / "config" / "secrets.json"
+
+
+def _load_gmail_token() -> Dict[str, Any]:
+    if not SECRETS_PATH.exists():
+        raise FileNotFoundError(f"Missing secrets file at {SECRETS_PATH}")
+
+    data = json.loads(SECRETS_PATH.read_text(encoding="utf-8"))
+    token = data.get("gmail_api_token")
+    if not isinstance(token, dict):
+        raise ValueError("gmail_api_token must be a JSON object containing OAuth credentials")
+    return token
+
+
+def _build_gmail_service() -> Any:
+    token_info = _load_gmail_token()
+
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+    except ImportError as exc:  # pragma: no cover - dependency provided in runtime env
+        raise RuntimeError("Google API client libraries are required to poll Gmail") from exc
+
+    scopes = token_info.get("scopes")
+    if not scopes:
+        scopes = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+    creds = Credentials.from_authorized_user_info(token_info, scopes=scopes)
+    if creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+
+    return build("gmail", "v1", credentials=creds)
+
+
+def _fetch_seen_ids() -> Sequence[str]:
+    engine = get_engine()
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT email_uuid FROM gmail_seen"))
+            return [str(row[0]) for row in result if row[0] is not None]
+    except Exception:
+        log.exception("Failed to load gmail_seen entries; treating as empty set")
+        return []
+
+
+def _normalize_gmail_id(message_id: Optional[str]) -> Optional[str]:
+    if not message_id:
+        return message_id
+
+    cleaned = message_id.strip()
+    hex_candidate = cleaned.replace("-", "")
+    hex_chars = set("0123456789abcdefABCDEF")
+    if 16 <= len(hex_candidate) <= 32 and set(hex_candidate).issubset(hex_chars):
+        try:
+            padded = hex_candidate.rjust(32, "0")
+            return str(uuid.UUID(padded))
+        except Exception:
+            log.debug("Message id %s looked hex-like but failed UUID normalization", message_id)
+    return cleaned
+
+
+def _determine_lookback_days() -> int:
+    engine = get_engine()
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                text("SELECT date_seen FROM gmail_seen ORDER BY date_seen DESC LIMIT 1")
+            ).first()
+    except Exception:
+        log.exception("Failed to query gmail_seen for last seen date; defaulting to 7 days")
+        return 7
+
+    if not row or not row[0]:
+        return 7
+
+    last_seen = row[0]
+    if isinstance(last_seen, datetime):
+        last_dt = last_seen
+    elif isinstance(last_seen, date):
+        last_dt = datetime.combine(last_seen, datetime.min.time(), tzinfo=timezone.utc)
+    else:
+        last_dt = datetime.now(timezone.utc)
+
+    if last_dt.tzinfo is None:
+        last_dt = last_dt.replace(tzinfo=timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    days_since = max(0, (now - last_dt).days)
+    return days_since + 7
+
+
+def _parse_email_date(header_value: Optional[str]) -> datetime:
+    if not header_value:
+        return datetime.now(timezone.utc)
+
+    try:
+        parsed = parsedate_to_datetime(header_value)
+    except (TypeError, ValueError):
+        parsed = None
+
+    if parsed is None:
+        return datetime.now(timezone.utc)
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _unwrap_db_payload(response: Any) -> Dict[str, Any]:
+    if hasattr(response, "get_json"):
+        try:
+            payload = response.get_json()
+        except Exception:
+            payload = {}
+    elif isinstance(response, dict):
+        payload = response
+    else:
+        payload = {}
+
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, dict):
+            return data
+    return payload if isinstance(payload, dict) else {}
+
+
+def _handle_gmail_message(msg: Dict[str, Any]) -> Dict[str, Any]:
+    headers = {h.get("name", "").lower(): h.get("value", "") for h in msg.get("payload", {}).get("headers", [])}
+    subject = headers.get("subject", "")
+    message_id = msg.get("id")
+    normalized_id = _normalize_gmail_id(message_id)
+
+    content = extract_text_content(msg.get("payload", {}))
+    html_body = content.get("html") or ""
+    text_body = content.get("text") or ""
+
+    order_number = None
+    order_url = None
+    if html_body:
+        order_number, order_url = extract_order_number_and_url(html_body)
+    if not order_number:
+        order_number = extract_order_number(subject) or extract_order_number(text_body)
+
+    if order_number:
+        order_number = order_number.strip()
+
+    email_date = _parse_email_date(headers.get("date"))
+
+    invoice_id: Optional[str] = None
+    invoice_error: Optional[str] = None
+
+    if order_number:
+        gmail_url = f"https://mail.google.com/mail/u/0/#all/{message_id}"
+        urls_value = gmail_url
+        if order_url:
+            urls_value = f"{urls_value};{order_url}"
+
+        invoice_payload: Dict[str, Any] = {
+            "date": email_date,
+            "order_number": order_number,
+            "shop_name": "",  # TODO: derive a shop/sender name from the message metadata.
+            "urls": urls_value,
+            "subject": subject,
+            "html": html_body or text_body,
+            "notes": "",
+            "has_been_processed": False,
+            "snooze": datetime.now(timezone.utc),
+            "is_deleted": False,
+        }
+
+        engine = get_engine()
+        invoice_resp, invoice_status = update_db_row_by_dict(engine, "invoices", "new", invoice_payload, fuzzy=False)
+        if invoice_status >= 400:
+            payload = _unwrap_db_payload(invoice_resp)
+            try:
+                invoice_error = json.dumps(payload)
+            except TypeError:
+                invoice_error = str(payload)
+            log.error("Failed to insert invoice for Gmail message %s: %s", message_id, invoice_error)
+        else:
+            payload = _unwrap_db_payload(invoice_resp)
+            invoice_id = payload.get("id") if isinstance(payload, dict) else None
+
+    gmail_payload: Dict[str, Any] = {
+        "email_uuid": normalized_id or message_id,
+        "date_seen": email_date,
+        "url1": None,
+        "url2": None,
+    }
+    if invoice_id:
+        gmail_payload["invoice_id"] = invoice_id
+
+    engine = get_engine()
+    gmail_resp, gmail_status = update_db_row_by_dict(engine, "gmail_seen", "new", gmail_payload, fuzzy=False)
+    if gmail_status >= 400:
+        payload = _unwrap_db_payload(gmail_resp)
+        log.error("Failed to insert gmail_seen row for message %s: %s", message_id, payload)
+
+    status = "invoice_created" if invoice_id else ("invoice_failed" if invoice_error else "no_order_number")
+
+    return {
+        "message_id": message_id,
+        "normalized_id": normalized_id,
+        "order_number": order_number,
+        "invoice_id": invoice_id,
+        "email_date": email_date.isoformat(),
+        "invoice_error": invoice_error,
+        "gmail_status": gmail_status,
+        "status": status,
+    }
+
+
+def _ingest_invoice_file(file_storage: FileStorage) -> Dict[str, Any]:
+    """Prepare metadata for a single uploaded invoice/email file.
+
+    TODO: Parse MIME and HTML structures similar to backend/automation/gmail_proc.py.
+    TODO: Reuse backend/automation/order_num_extract.py heuristics to derive order identifiers.
+    TODO: Map parsed fields into the invoice tables defined in backend/schemas/schema.sql.
+    """
+    return {
+        "filename": file_storage.filename or "",
+        "status": "pending",
+        "notes": "TODO: implement invoice ingestion pipeline.",
+    }
+
+
+@bp.route("/checkemail", methods=["POST"])
+@login_required
+def check_email() -> Any:
+    log.info("Mailbox check requested")
+
+    try:
+        service = _build_gmail_service()
+    except Exception as exc:
+        log.exception("Unable to initialise Gmail client")
+        return jsonify({"ok": False, "error": "Failed to initialise Gmail client", "detail": str(exc)}), 500
+
+    lookback_days = _determine_lookback_days()
+    query = gmail_date_x_days_query(lookback_days)
+
+    try:
+        message_ids = list_message_ids(service, query)
+    except Exception as exc:  # pragma: no cover - network interaction
+        log.exception("Unable to list Gmail messages for query %s", query)
+        return jsonify({"ok": False, "error": "Failed to query Gmail", "detail": str(exc)}), 502
+
+    seen_ids = list(_fetch_seen_ids())
+    seen_normalized = {_normalize_gmail_id(value) for value in seen_ids if value}
+
+    new_ids: List[str] = []
+    for mid in message_ids:
+        normalized = _normalize_gmail_id(mid)
+        if mid in seen_ids or (normalized and normalized in seen_normalized):
+            continue
+        new_ids.append(mid)
+
+    processed: List[Dict[str, Any]] = []
+    for mid in new_ids:
+        try:
+            msg = get_full_message(service, mid)
+        except Exception as exc:  # pragma: no cover - network interaction
+            log.exception("Failed to fetch Gmail message %s", mid)
+            processed.append({"message_id": mid, "status": "fetch_error", "error": str(exc)})
+            continue
+
+        try:
+            result = _handle_gmail_message(msg)
+            processed.append(result)
+        except Exception as exc:
+            log.exception("Failed to process Gmail message %s", mid)
+            processed.append({"message_id": mid, "status": "processing_error", "error": str(exc)})
+
+    summary = {
+        "ok": True,
+        "queried_days": lookback_days,
+        "query": query,
+        "checked": len(message_ids),
+        "new_messages": len(new_ids),
+        "processed": processed,
+    }
+
+    return jsonify(summary)
+
+
+@bp.route("/invoiceupload", methods=["POST"])
+@login_required
+def invoice_upload() -> Any:
+    """Accept uploaded invoice files and process them like inbound emails.
+
+    TODO: Support bulk uploads by streaming each file into the same pipeline used for Gmail messages.
+    TODO: Capture missing metadata (sender, subject, timestamps) with sensible defaults when absent.
+    TODO: Persist invoice and attachment records according to backend/schemas/schema.sql.
+    """
+    files = request.files.getlist("files") or request.files.getlist("file")
+    if not files:
+        return jsonify({"error": "No invoice files provided."}), 400
+
+    processed: List[Dict[str, Any]] = []
+    for storage in files:
+        if not storage:
+            continue
+        processed.append(_ingest_invoice_file(storage))
+        # TODO: Persist each result just like a processed Gmail message would be saved.
+
+    return jsonify(
+        {
+            "ok": True,
+            "processed": processed,
+            "message": "Invoice upload accepted. TODO: persist invoices and metadata.",
+        }
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .errors import register_error_handlers
 from .static_server import bp_overlay, get_public_html_path
 from .imagehandler import bp_image
 from .user_login import bp as bp_auth
+from .invoice_handlers import bp as bp_invoice
 from .items import bp as bp_items
 from .maint import bp as bp_maint
 from .search import bp as bp_search
@@ -43,6 +44,7 @@ def create_app():
     app.register_blueprint(bp_overlay)
     app.register_blueprint(bp_image)
     app.register_blueprint(bp_search)
+    app.register_blueprint(bp_invoice)
     app.register_blueprint(bp_items)
     app.register_blueprint(bp_maint)
 

--- a/frontend/src/pages/LedgerSearchPage.tsx
+++ b/frontend/src/pages/LedgerSearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import SearchPanel from "../app/components/SearchPanel";
@@ -6,16 +6,199 @@ import SearchPanel from "../app/components/SearchPanel";
 const LedgerSearchPage: React.FC = () => {
   const { xyz } = useParams<{ xyz?: string }>();
   const prefilled = useMemo(() => (xyz ? decodeURIComponent(xyz) : ""), [xyz]);
+  const [searchPrefill, setSearchPrefill] = useState(prefilled);
+  const [checkEmailBusy, setCheckEmailBusy] = useState(false);
+  const [uploadBusy, setUploadBusy] = useState(false);
+  const [modalMessage, setModalMessage] = useState<
+    | {
+        title: string;
+        body: string;
+      }
+    | null
+  >(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setSearchPrefill(prefilled);
+  }, [prefilled]);
+
+  const showModal = (title: string, body: string) => {
+    setModalMessage({ title, body });
+  };
+
+  const handleCheckEmail = async () => {
+    if (checkEmailBusy) {
+      return;
+    }
+    setCheckEmailBusy(true);
+    try {
+      const response = await fetch("/api/checkemail", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      let payload: any = null;
+      try {
+        payload = await response.json();
+      } catch (error) {
+        payload = null;
+      }
+      if (!response.ok) {
+        const message =
+          (payload && (payload.error || payload.message)) ||
+          response.statusText ||
+          "Failed to contact email checker.";
+        throw new Error(message);
+      }
+      setSearchPrefill("* ?!has_been_processed \\bydate \\orderrev");
+      const message =
+        (payload && (payload.message || payload.detail)) ||
+        "Email check completed successfully.";
+      showModal("Email check complete", message);
+    } catch (error: any) {
+      const message = error?.message || "Email check failed.";
+      showModal("Email check failed", message);
+    } finally {
+      setCheckEmailBusy(false);
+    }
+  };
+
+  const handleFileSelection = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = event.target.files;
+    if (!files) {
+      setSelectedFiles([]);
+      return;
+    }
+    setSelectedFiles(Array.from(files));
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFiles.length || uploadBusy) {
+      return;
+    }
+    setUploadBusy(true);
+    try {
+      const formData = new FormData();
+      selectedFiles.forEach((file) => {
+        formData.append("files", file);
+      });
+      const response = await fetch("/api/invoiceupload", {
+        method: "POST",
+        body: formData,
+      });
+      let payload: any = null;
+      try {
+        payload = await response.json();
+      } catch (error) {
+        payload = null;
+      }
+      if (!response.ok) {
+        const message =
+          (payload && (payload.error || payload.message)) ||
+          response.statusText ||
+          "Invoice upload failed.";
+        throw new Error(message);
+      }
+      setSearchPrefill("* ?!has_been_processed \\bydate \\orderrev");
+      const message =
+        (payload && (payload.message || payload.detail)) ||
+        "Invoices uploaded successfully.";
+      showModal("Invoice upload complete", message);
+      setSelectedFiles([]);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    } catch (error: any) {
+      const message = error?.message || "Invoice upload failed.";
+      showModal("Invoice upload failed", message);
+    } finally {
+      setUploadBusy(false);
+    }
+  };
+
+  const renderBusyIndicator = (message: string) => (
+    <div className="d-flex align-items-center gap-2 mt-2" role="status">
+      <div className="spinner-border spinner-border-sm" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
 
   return (
     <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
       <h1 className="h3 mb-4">Search Invoices</h1>
       <SearchPanel
         displayedTitle="Invoices"
-        prefilledQuery={prefilled}
+        prefilledQuery={searchPrefill}
         tableName="invoices"
         allowDelete
       />
+
+      <div className="mt-5">
+        <h2 className="h5">Check email for invoices</h2>
+        <p className="text-muted">
+          Trigger the email processor to pull the latest invoices from the mailbox.
+        </p>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={handleCheckEmail}
+          disabled={checkEmailBusy}
+        >
+          {checkEmailBusy ? "Checking…" : "Check email"}
+        </button>
+        {checkEmailBusy && renderBusyIndicator("Checking mailbox for invoices…")}
+      </div>
+
+      <div className="mt-4">
+        <h2 className="h5">Upload invoice files</h2>
+        <p className="text-muted">
+          Upload archived email files (.mht, .mhtml, .htm, .html) to import invoices directly.
+        </p>
+        <div className="d-flex flex-column flex-sm-row align-items-start gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="form-control"
+            accept=".mht,.mhtm,.mhtml,.htm,.html"
+            multiple
+            onChange={handleFileSelection}
+            disabled={uploadBusy}
+          />
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={handleUpload}
+            disabled={uploadBusy || !selectedFiles.length}
+          >
+            {uploadBusy ? "Uploading…" : "Upload"}
+          </button>
+        </div>
+        {uploadBusy && renderBusyIndicator("Uploading invoices…")}
+      </div>
+
+      {modalMessage && (
+        <div
+          className="position-fixed top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center"
+          style={{ backgroundColor: "rgba(0, 0, 0, 0.35)", zIndex: 1050 }}
+        >
+          <div className="bg-white border rounded-3 shadow p-4" role="dialog" aria-modal="true">
+            <h3 className="h5">{modalMessage.title}</h3>
+            <p className="mb-4">{modalMessage.body}</p>
+            <div className="text-end">
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => setModalMessage(null)}
+              >
+                OK
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement the /api/checkemail endpoint to poll Gmail, derive invoice metadata, and persist gmail_seen rows with logging and robust error handling
- add a parameterized gmail_date_x_days_query helper so the handler can adjust the mailbox lookback window dynamically

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d4d0b8aeec832b8677d0cfc8d7e3d6