### PR TITLE
Support private config directory for logs and Gmail token

### DIFF
--- a/backend/app/invoice_handlers.py
+++ b/backend/app/invoice_handlers.py
@@ -24,6 +24,7 @@ from automation.html_invoice_helpers import parse_mhtml_from_string, sniff_forma
 from lxml import html as lxml_html
 from app.db import get_db_item_as_dict, get_engine, update_db_row_by_dict, unwrap_db_result
 
+from .config_loader import get_private_dir_path
 from .user_login import login_required
 
 bp = Blueprint("invoice_handlers", __name__, url_prefix="/api")
@@ -34,8 +35,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SECRETS_PATH = REPO_ROOT / "config" / "secrets.json"
 
 
+def _gmail_token_path() -> Path:
+    """
+    Resolve the Gmail OAuth token cache location, honoring the optional private_dir hint.
+    """
+    private_dir = get_private_dir_path()
+    if private_dir is not None:
+        # Keep the token beside other private runtime artifacts when configured.
+        return Path(private_dir) / "gmail_token.json"
+    return SECRETS_PATH.with_name("gmail_token.json")
+
+
 def _load_gmail_token() -> Dict[str, Any]:
-    token_path = SECRETS_PATH.with_name("gmail_token.json")
+    token_path = _gmail_token_path()
 
     if token_path.exists():
         raw_token = token_path.read_text(encoding="utf-8")
@@ -60,7 +72,7 @@ def _load_gmail_token() -> Dict[str, Any]:
 
 
 def _build_gmail_service() -> Any:
-    token_path = SECRETS_PATH.with_name("gmail_token.json")
+    token_path = _gmail_token_path()
     token_info = _load_gmail_token()
 
     try:
@@ -84,6 +96,7 @@ def _build_gmail_service() -> Any:
         persist_token = True
 
     if persist_token:
+        token_path.parent.mkdir(parents=True, exist_ok=True)
         token_path.write_text(creds.to_json(), encoding="utf-8")
 
     return build("gmail", "v1", credentials=creds)

--- a/backend/app/logging_setup.py
+++ b/backend/app/logging_setup.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Optional
 from logging.handlers import RotatingFileHandler
 
+from .config_loader import get_private_dir_path
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 class DateSizeRotatingFileHandler(RotatingFileHandler):
@@ -89,7 +91,11 @@ def start_log(
     if log_dir is None:
         log_dir = os.getenv("LOG_DIR", None)
 
-    # TODO: read log dir from appconfig.json
+    if log_dir is None:
+        private_dir = get_private_dir_path()
+        if private_dir is not None:
+            # Store logs within the private directory when available so sensitive data stays together.
+            log_dir = Path(private_dir) / "logs"
 
     if log_dir is None:
         log_dir = REPO_ROOT / "var" / "logs"


### PR DESCRIPTION
## Summary
- add a helper to resolve the optional private_dir path from appconfig.json
- write backend logs beneath the configured private directory when available
- read and persist Gmail OAuth tokens within the private directory for better isolation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d658d9d09c832bb6ad308ba042629a