### PR TITLE
Ensure clipboard uploads pass FileStorage objects through

### DIFF
--- a/backend/app/image_handler.py
+++ b/backend/app/image_handler.py
@@ -260,7 +260,9 @@ def store_image_for_item(
 ) -> Dict[str, Any]:
     tmp_dir, imgs_root = _ensure_dirs()
 
-    provided = [bool(upload), bool(source_url), bool(data_url)]
+    # Treat any provided upload object as a valid source even if the filename is empty.
+    upload_provided = upload is not None
+    provided = [upload_provided, bool(source_url), bool(data_url)]
     if sum(provided) != 1:
         raise BadRequest("Provide exactly one image source")
 
@@ -447,13 +449,15 @@ def handle_img_upload(item_id: str):
     is_clipboard_upload = clipboard_flag not in {"", "0", "false", "False"}
 
     upload = request.files.get("img_file")
+    has_upload_object = upload is not None
+    # Flask returns FileStorage objects that evaluate to False when the filename is empty.
     url = request.form.get("img_url", "").strip()
     data_url = request.form.get("img_data", "").strip()
 
     try:
         result = store_image_for_item(
             item_uuid=item_uuid,
-            upload=upload if upload else None,
+            upload=upload if has_upload_object else None,
             source_url=url,
             data_url=data_url,
             clipboard_upload=is_clipboard_upload or bool(data_url),


### PR DESCRIPTION
## Summary
- pass through FileStorage uploads even when they have empty filenames so clipboard submissions count as a provided source
- document the reason with an inline comment for future reference

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d66157a298832bbbe44875f45e8241