### PR TITLE
Adjust association emoji display for special values

### DIFF
--- a/frontend/src/app/components/SearchPanel.tsx
+++ b/frontend/src/app/components/SearchPanel.tsx
@@ -479,14 +479,20 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
   );
 
   const formatAssociationEmojis = useCallback((value: number): string => {
-    const normalized = Number.isFinite(value)
-      ? value & ALL_ASSOCIATION_MASK
-      : 0;
+    if (!Number.isFinite(value)) {
+      return "";
+    }
+    if (value < 0) {
+      // Negative association values represent unknown states, so do not render an icon.
+      return "";
+    }
+    const normalized = value & ALL_ASSOCIATION_MASK;
     const icons = collect_emoji_characters_from_int(normalized);
     if (icons.length > 0) {
       return icons.join("");
     }
-    return normalized === 0 ? "⚫" : "";
+    // Show a question mark when the association value is explicitly zero or unrecognized.
+    return "❓";
   }, []);
 
   const containmentChecked = int_has_containment(associationBits);


### PR DESCRIPTION
## Summary
- update the association emoji formatter so zero displays a question mark and negative values show nothing
- document the new handling with inline comments for clarity

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d667dce394832ba2d094978d846c9e