### PR TITLE
Improve referer handling for image downloads

### DIFF
--- a/backend/app/image_handler.py
+++ b/backend/app/image_handler.py
@@ -156,7 +156,10 @@ def _download_to_tmp(url: str, tmp_dir: Path) -> Path:
         "Connection": "keep-alive",
     }
     if parsed_url.scheme and parsed_url.netloc:
-        polite_headers["Referer"] = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        # Set the Referer header to the root of the source site so that our request
+        # appears to originate from normal site navigation rather than a blank tab.
+        referer_root = f"{parsed_url.scheme}://{parsed_url.netloc}/"
+        polite_headers["Referer"] = referer_root
 
     try:
         resp = requests.get(


### PR DESCRIPTION
## Summary
- derive the Referer header from the root of the requested image domain
- document the intent behind the Referer spoofing for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d735640bd4832b8ffd553ad6a72917