### PR TITLE
Handle double carriage returns when normalizing line endings

### DIFF
--- a/scripts/fix_all_line_endings.py
+++ b/scripts/fix_all_line_endings.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -18,7 +19,12 @@ def normalize_to_crlf(path: Path) -> bool:
     if b"\0" in data or b"\r\n" not in data:
         return False
 
-    normalized = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    # When a file contains multiple carriage return characters before a newline,
+    # such as "\r\r\n", we collapse that sequence down to a single carriage
+    # return to avoid creating duplicate blank lines after normalization.
+    cleaned = re.sub(rb"\r+\n", b"\r\n", data)
+
+    normalized = cleaned.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
     converted = normalized.replace(b"\n", b"\r\n")
 
     if converted != data:


### PR DESCRIPTION
## Summary
- ensure fix_all_line_endings.py collapses repeated carriage returns before normalization
- add explanation comment for the new cleanup step

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d75c339a40832b9c6fafa08e7407d6