### PR TITLE
Handle obfuscated string and dict lists when merging examples

### DIFF
--- a/scripts/config_json_example_creator.py
+++ b/scripts/config_json_example_creator.py
@@ -57,8 +57,27 @@ def merge_example_content(existing: Any, updated: Any) -> Any:
             existing_value = existing.get(key) if isinstance(existing, dict) else None
             merged[key] = merge_example_content(existing_value, updated_value)
         return merged
+    if isinstance(updated, list):
+        if isinstance(existing, list):
+            if len(existing) == len(updated):
+                existing_all_strings = all(isinstance(item, str) for item in existing)
+                updated_all_strings = all(isinstance(item, str) for item in updated)
+                if existing_all_strings and updated_all_strings:
+                    # When both lists contain string data with matching lengths, keep the existing obfuscation.
+                    return existing
+                existing_all_dicts = all(isinstance(item, dict) for item in existing)
+                updated_all_dicts = all(isinstance(item, dict) for item in updated)
+                if existing_all_dicts and updated_all_dicts:
+                    merged_items = []
+                    for existing_item, updated_item in zip(existing, updated):
+                        # Merge dictionaries element-by-element so nested content retains any prior obfuscation.
+                        merged_items.append(merge_example_content(existing_item, updated_item))
+                    return merged_items
+        # Lists either differ in length or contain non-string entries, so use the updated list as-is.
+        return updated
     if isinstance(updated, str):
         if isinstance(existing, str) and len(existing) == len(updated):
+            # Preserve the previously obfuscated string when it has the same length as the updated value.
             return existing
         return updated
     return updated if updated is not None else existing


### PR DESCRIPTION
## Summary
- keep existing example values when a list of strings retains the same length during an update
- recursively merge equally sized lists of dictionaries so nested example data retains prior obfuscation
- document the preservation behavior for both lists and individual strings with inline comments

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d75dafe0ec832b99981c60e2d0b5e0