### PR TITLE
Hide placeholder opened timestamp when pin missing

### DIFF
--- a/frontend/src/pages/InvoicePage.tsx
+++ b/frontend/src/pages/InvoicePage.tsx
@@ -602,13 +602,15 @@ const InvoicePage: React.FC = () => {
       {/* Pin controls live at the bottom so they are easy to access after reviewing invoice details */}
       <div className="mt-4">
         <div className="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-3">
-          <div className="fw-semibold">
-            {/* Always report the last timestamp even if it is outside of the active window */}
-            📌🕒 Opened at: {pinDetails.readable}
-            {pinDetails.instant && !isPinCurrentlyActive && (
-              <span className="text-muted ms-2">(pin expired)</span>
-            )}
-          </div>
+          {pinDetails.instant && (
+            <div className="fw-semibold">
+              {/* Only render the opened timestamp when a valid pin exists to avoid placeholder text */}
+              📌🕒 Opened at: {pinDetails.readable}
+              {!isPinCurrentlyActive && (
+                <span className="text-muted ms-2">(pin expired)</span>
+              )}
+            </div>
+          )}
           <div className="d-flex flex-wrap gap-2">
             {!isPinCurrentlyActive && (
               <button

--- a/frontend/src/pages/ItemPage.tsx
+++ b/frontend/src/pages/ItemPage.tsx
@@ -616,13 +616,15 @@ const ItemPage: React.FC = () => {
       {/* Pin management controls appear before related search panels so they are easy to find */}
       <div className="mb-4">
         <div className="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-3">
-          <div className="fw-semibold">
-            {/* Always show the last known opened time so the operator has context */}
-            📌🕒 Opened at: {pinDetails.readable}
-            {pinDetails.instant && !isPinCurrentlyActive && (
-              <span className="text-muted ms-2">(pin expired)</span>
-            )}
-          </div>
+          {pinDetails.instant && (
+            <div className="fw-semibold">
+              {/* Only display the opened timestamp when a pin exists so operators do not see placeholder text */}
+              📌🕒 Opened at: {pinDetails.readable}
+              {!isPinCurrentlyActive && (
+                <span className="text-muted ms-2">(pin expired)</span>
+              )}
+            </div>
+          )}
           <div className="d-flex flex-wrap gap-2">
             {!isPinCurrentlyActive && (
               <button


### PR DESCRIPTION
## Summary
- render the pin timestamp on the item page only when a valid opened pin exists
- render the pin timestamp on the invoice page only when a valid opened pin exists

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d76613fa44832b9f6a1e7e25928e08