### PR TITLE
Allow LAN access to Vite dev server

### DIFF
--- a/dev-doc/quick-server-launch-for-dev.md
+++ b/dev-doc/quick-server-launch-for-dev.md
@@ -29,3 +29,11 @@ On Windows, `cd` into project root
 `npm run dev`
 
 This works because `<root>/package.json` has been setup with a longer script that launches Flask concurrently
+
+# Allow LAN access to the Vite dev server
+
+1. The Vite configuration (`frontend/vite.config.ts`) now binds to `0.0.0.0`. This makes the dev server listen on every network interface so devices on your Wi-Fi can reach it.
+2. After running `npm run -w frontend dev`, use the `Network:` URL that Vite prints (for example, `http://192.168.1.174:5173/`).
+3. The first time Node.js opens the port, Windows Defender Firewall might prompt for access. Allow the connection on private networks. If the prompt never appeared, create an inbound firewall rule that allows TCP 5173 for the Node.js runtime.
+4. Confirm your phone and computer are on the same subnet (both `192.168.1.x`). A quick `ipconfig` on Windows and checking the phone's Wi-Fi details is usually enough.
+5. If you still cannot connect, verify no VPN or security suite is blocking local traffic, then retry the LAN URL from the phone.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,19 +6,20 @@ export default defineConfig({
   plugins: [react()],
   build: { minify: false },
   server: {
-    port: 5173,          // dev server port (change if you like)
-    // strictPort: true, // uncomment to fail if 5173 is taken
+    host: '0.0.0.0',        // bind to all interfaces so LAN devices can reach Vite
+    port: 5173,             // development server port (change if you like)
+    // strictPort: true,    // uncomment to fail if 5173 is taken
     proxy: {
       '/api': {
         target: 'http://127.0.0.1:5000',   // Flask server
         changeOrigin: true,
-        // If Flask routes are like "/items" (no "/api" prefix), strip it:
+        // If Flask routes are like \"/items\" (no \"/api\" prefix), strip it:
         // rewrite: (path) => path.replace(/^\/api/, ''),
       },
       '/imgs': {
         target: 'http://127.0.0.1:5000',   // Flask server
         changeOrigin: true,
-        // If Flask routes are like "/items" (no "/api" prefix), strip it:
+        // If Flask routes are like \"/items\" (no \"/api\" prefix), strip it:
         // rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },


### PR DESCRIPTION
## Summary
- bind the Vite dev server to 0.0.0.0 so other LAN devices can reach the frontend
- document the LAN testing workflow and the Windows firewall considerations in the quick start guide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d768c1cb10832b8d7953ca985afac1