### PR TITLE
Add shop handler framework for invoices

### DIFF
--- a/backend/shop_handler/__init__.py
+++ b/backend/shop_handler/__init__.py
@@ -1,0 +1,14 @@
+"""Helpers for selecting specialized shop handlers."""
+
+from .shop_handler import ShopHandler, GenericShopHandler
+from .amazon_handler import AmazonHandler
+from .digikey_handler import DigiKeyHandler
+from .mcmastercarr_handler import McMasterCarrHandler
+
+__all__ = [
+    "ShopHandler",
+    "GenericShopHandler",
+    "AmazonHandler",
+    "DigiKeyHandler",
+    "McMasterCarrHandler",
+]

--- a/backend/shop_handler/amazon_handler.py
+++ b/backend/shop_handler/amazon_handler.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+from .shop_handler import ShopHandler
+
+
+class AmazonHandler(ShopHandler):
+    """Handler for Amazon order invoices."""
+
+    POSSIBLE_NAMES = (
+        "Amazon",
+        "Amazon.com",
+        "Amazon.com Services",
+        "Amazon Marketplace",
+    )
+    ORDER_NUMBER_REGEX = re.compile(r"(?i)order\s*[#:]*\s*(\d{3}-\d{7}-\d{7})")
+
+    def guess_items(self) -> List[Dict[str, str]]:
+        # TODO: Implement Amazon specific extraction logic when the DOM structure is understood.
+        return []

--- a/backend/shop_handler/digikey_handler.py
+++ b/backend/shop_handler/digikey_handler.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+from .shop_handler import ShopHandler
+
+
+class DigiKeyHandler(ShopHandler):
+    """Handler for Digi-Key order invoices."""
+
+    POSSIBLE_NAMES = (
+        "Digi-Key",
+        "Digi Key",
+        "DigiKey",
+    )
+    ORDER_NUMBER_REGEX = re.compile(r"(?i)order\s*[#:]*\s*(\d{7,10})")
+
+    def guess_items(self) -> List[Dict[str, str]]:
+        # TODO: Implement Digi-Key specific extraction logic when the DOM structure is understood.
+        return []

--- a/backend/shop_handler/mcmastercarr_handler.py
+++ b/backend/shop_handler/mcmastercarr_handler.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+from .shop_handler import ShopHandler
+
+
+class McMasterCarrHandler(ShopHandler):
+    """Handler for McMaster-Carr order invoices."""
+
+    POSSIBLE_NAMES = (
+        "McMaster-Carr",
+        "McMaster",
+    )
+    ORDER_NUMBER_REGEX = re.compile(r"(?i)order\s*[#:]*\s*(\d{4}[A-Z]{5})")
+
+    def guess_items(self) -> List[Dict[str, str]]:
+        # TODO: Implement McMaster-Carr specific extraction logic when the DOM structure is understood.
+        return []

--- a/backend/shop_handler/shop_handler.py
+++ b/backend/shop_handler/shop_handler.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type
+
+from lxml import etree
+from lxml import html as lxml_html
+
+from automation.html_dom_finder import analyze as analyze_dom_report, sanitize_dom
+from automation.order_num_extract import extract_order_number
+
+log = logging.getLogger(__name__)
+
+
+class ShopHandler:
+    """Base class for extracting store specific information from invoices."""
+
+    POSSIBLE_NAMES: ClassVar[Sequence[str]] = tuple()
+    ORDER_NUMBER_REGEX: ClassVar[Optional[re.Pattern[str]]] = None
+
+    def __init__(self, raw_html: str, sanitized_root: etree._Element, sanitized_html: str) -> None:
+        self.raw_html = raw_html
+        self.sanitized_root = sanitized_root
+        self.sanitized_html = sanitized_html
+        self._sanitized_text_cache: Optional[str] = None
+        self._last_dom_report: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def ingest_html(cls, raw_html: str) -> "ShopHandler":
+        if not isinstance(raw_html, str) or not raw_html.strip():
+            raise ValueError("HTML content must be a non-empty string.")
+
+        try:
+            root = lxml_html.fromstring(raw_html)
+        except Exception as exc:
+            log.debug("Falling back to HTML fragment parsing during ingestion: %s", exc)
+            root = lxml_html.fragment_fromstring(raw_html, create_parent=True)
+
+        sanitized_root = sanitize_dom(root)
+        sanitized_html = lxml_html.tostring(sanitized_root, encoding="unicode")
+        normalized_text = sanitized_html.lower()
+
+        specific_handlers = cls._get_specific_handlers()
+        name_counts: Dict[Type[ShopHandler], int] = {}
+        for handler_cls in specific_handlers:
+            name_counts[handler_cls] = handler_cls._count_name_hits(normalized_text)
+
+        best_handler: Type[ShopHandler] = GenericShopHandler
+        if name_counts:
+            sorted_counts: List[Tuple[Type[ShopHandler], int]] = sorted(
+                name_counts.items(), key=lambda item: item[1], reverse=True
+            )
+            top_cls, top_hits = sorted_counts[0]
+            other_hits = [count for _, count in sorted_counts[1:]]
+            if top_hits > 0 and all(top_hits > value for value in other_hits):
+                best_handler = top_cls
+
+        return best_handler(raw_html, sanitized_root, sanitized_html)
+
+    @classmethod
+    def _get_specific_handlers(cls) -> Sequence[Type["ShopHandler"]]:
+        from .amazon_handler import AmazonHandler
+        from .digikey_handler import DigiKeyHandler
+        from .mcmastercarr_handler import McMasterCarrHandler
+
+        return (AmazonHandler, DigiKeyHandler, McMasterCarrHandler)
+
+    @classmethod
+    def _count_name_hits(cls, haystack: str) -> int:
+        if not cls.POSSIBLE_NAMES:
+            return 0
+
+        total = 0
+        for candidate in cls.POSSIBLE_NAMES:
+            token = candidate.strip().lower()
+            if not token:
+                continue
+            total += haystack.count(token)
+        return total
+
+    @classmethod
+    def get_shop_name(cls) -> str:
+        if not cls.POSSIBLE_NAMES:
+            return ""
+        return cls.POSSIBLE_NAMES[0]
+
+    def as_specific_handler(self) -> "ShopHandler":
+        return self
+
+    def get_order_number(self) -> Optional[str]:
+        pattern = self.ORDER_NUMBER_REGEX
+        if pattern is None:
+            return None
+        match = pattern.search(self._get_sanitized_text())
+        if match:
+            return match.group(1) if match.groups() else match.group(0)
+        return None
+
+    def guess_items(self) -> List[Dict[str, str]]:
+        # TODO: Implement store specific item extraction when structure is known.
+        return []
+
+    def build_auto_summary(self) -> str:
+        entries: List[Dict[str, str]] = []
+        shop_name = self.get_shop_name()
+        items = self.guess_items()
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text_value = str(item.get("text", ""))
+            url_value = str(item.get("url", ""))
+            entry: Dict[str, str] = {
+                "text": text_value,
+                "url": url_value,
+                "shop": shop_name,
+            }
+            entries.append(entry)
+        return json.dumps(entries, ensure_ascii=False)
+
+    def _get_sanitized_text(self) -> str:
+        if self._sanitized_text_cache is None:
+            self._sanitized_text_cache = lxml_html.tostring(
+                self.sanitized_root, encoding="unicode", method="text"
+            )
+        return self._sanitized_text_cache
+
+    def get_dom_report(self) -> Optional[Dict[str, Any]]:
+        return self._last_dom_report
+
+
+class GenericShopHandler(ShopHandler):
+    ORDER_NUMBER_REGEX = None
+
+    def get_order_number(self) -> Optional[str]:
+        try:
+            return extract_order_number(self.raw_html)
+        except Exception:
+            log.exception("Generic order number extraction failed")
+            return None
+
+    def guess_items(self) -> List[Dict[str, str]]:
+        try:
+            report, _ = analyze_dom_report(self.raw_html)
+        except Exception:
+            log.exception("Failed to analyze DOM for generic handler")
+            return []
+
+        self._last_dom_report = report if isinstance(report, dict) else None
+        summary: List[Dict[str, str]] = []
+        candidates = report.get("top_candidates") if isinstance(report, dict) else None
+        if not isinstance(candidates, list):
+            candidates = []
+
+        for item in candidates:
+            if not isinstance(item, dict):
+                continue
+            url = (item.get("url") or "").strip()
+            preview_text = (item.get("preview_text") or "").strip()
+            anchor_text = (item.get("anchor_text") or "").strip()
+
+            chosen_text = ""
+            if url:
+                chosen_text = anchor_text if len(anchor_text) >= 12 else preview_text
+                if len(chosen_text) < 12:
+                    chosen_text = ""
+            else:
+                if len(preview_text) >= 12:
+                    chosen_text = preview_text
+
+            if chosen_text or url:
+                summary.append({
+                    "text": chosen_text if chosen_text else "",
+                    "url": url,
+                })
+
+        return summary


### PR DESCRIPTION
## Summary
- add a shared ShopHandler implementation that selects specialized invoice parsers and retains the generic auto-summary workflow
- introduce Amazon, Digi-Key, and McMaster-Carr handler stubs with name aliases and order-number validation
- update invoice ingestion routines to use the handler framework for auto summaries, shop naming, and fallback order detection

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d770703724832b90d73ce9517ddbaa