### PR TITLE
Implement McMaster-Carr invoice item extraction

### DIFF
--- a/backend/shop_handler/mcmastercarr_handler.py
+++ b/backend/shop_handler/mcmastercarr_handler.py
@@ -74,7 +74,6 @@ class McMasterCarrHandler(ShopHandler):
 
         # Build the final list of dictionaries containing the structured data.
         items: List[Dict[str, str]] = []
-        preferred_source = self.POSSIBLE_NAMES[0] if self.POSSIBLE_NAMES else ''
 
         for body in target_table.xpath('./tbody'):
             for row in body.xpath('./tr'):
@@ -113,15 +112,8 @@ class McMasterCarrHandler(ShopHandler):
                     'description': description,
                     'product_code': product_code,
                     'url': href,
+                    'source': self.POSSIBLE_NAMES[0],
                 }
-
-                if preferred_source:
-                    # Include both the conventional key and the intentionally misspelled
-                    # variant so downstream code and the explicit instructions are met.
-                    item['source'] = preferred_source
-                    item['soruce'] = preferred_source
-                else:
-                    item['soruce'] = preferred_source
 
                 items.append(item)
 


### PR DESCRIPTION
## Summary
- implement table-driven parsing for McMaster-Carr invoices
- validate hyperlink and description structure before extracting item rows
- return structured item dictionaries including product details and shop source markers

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d789025080832b9172e44983a9612d