### PR TITLE
Move bool helper into shared helpers module

### DIFF
--- a/backend/app/helpers.py
+++ b/backend/app/helpers.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import html as _html
 import re
+import unicodedata
+from typing import Any, Union
 
 def normalize_pg_uuid(s: str) -> str:
     """
@@ -35,10 +38,19 @@ def normalize_pg_uuid(s: str) -> str:
     cleaned = cleaned.lower()
     return f"{cleaned[0:8]}-{cleaned[8:12]}-{cleaned[12:16]}-{cleaned[16:20]}-{cleaned[20:32]}"
 
-import re
-import html as _html
-import unicodedata
-from typing import Union, Any
+def _to_bool(value: Any) -> bool:
+    """Convert loose truthy and falsey values into a strict bool."""
+    # Strings get special handling so user-supplied query parameters behave predictably.
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized:
+            return False
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    # Fallback to Python's general truthiness rules for everything else.
+    return bool(value)
 
 def sanitize_html_for_pg(
     value: Union[str, bytes, Any],

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -14,7 +14,7 @@ from .user_login import login_required
 from .db import deduplicate_rows, get_db_item_as_dict, get_engine, get_or_create_session
 from .search_expression import SearchQuery, get_sql_order_and_limit
 from .embeddings import search_items_by_embeddings
-from .helpers import fuzzy_levenshtein_at_most, normalize_pg_uuid
+from .helpers import fuzzy_levenshtein_at_most, normalize_pg_uuid, _to_bool
 from .items import augment_item_dict, get_item_thumbnails
 from .slugify import slugify
 
@@ -544,18 +544,7 @@ def _finalize_invoice_rows(rows: Iterable[Mapping[str, Any]]) -> List[Dict[str, 
     return deduplicate_rows(normalized, key="pk")
 
 
-def _to_bool(value: Any) -> bool:
-    """Convert loose truthy/falsey values to :class:`bool`."""
 
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if not normalized:
-            return False
-        if normalized in {"1", "true", "yes", "on"}:
-            return True
-        if normalized in {"0", "false", "no", "off"}:
-            return False
-    return bool(value)
 
 
 def search_items(


### PR DESCRIPTION
## Summary
- move the `_to_bool` normalization helper into `backend/app/helpers.py` for reuse
- update the search blueprint to import the shared helper instead of hosting a duplicate definition

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68d7bb7d805c832b972b9f3e72444bfa