### PR TITLE
Fix ai_test_query direct invocation import paths

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Provide package metadata so direct script execution can import the backend package."""

--- a/backend/automation/__init__.py
+++ b/backend/automation/__init__.py
@@ -1,0 +1,1 @@
+"""Expose automation utilities as a proper package for downstream imports."""

--- a/backend/automation/ai_helpers.py
+++ b/backend/automation/ai_helpers.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
-import os, sys, pathlib
+import os
+import sys
+from pathlib import Path
 import json
 import requests
 
 from typing import List, Union
+
+# Guarantee that the repository root is discoverable on sys.path when this
+# module is invoked directly. This keeps imports such as app.config_loader
+# working during local scripting without requiring a package-style launch.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from openai import OpenAI
 from app.config_loader import CONFIG_DIR, CONFIG_PATH, load_app_config

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Allow tool scripts to reference shared helpers via package imports."""

--- a/backend/tools/ai_test_query.py
+++ b/backend/tools/ai_test_query.py
@@ -1,8 +1,18 @@
 """Utility script to send a test query to an AI model defined by AiInstance."""
 import argparse
+import sys
 import time
+from pathlib import Path
+
+# Ensure the repository root is discoverable when the script is run directly with
+# ``python backend/tools/ai_test_query.py``. This keeps imports of our internal
+# packages reliable without requiring ``python -m`` invocation.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from backend.automation.ai_helpers import AiInstance
+
 
 def main() -> None:
     """Parse arguments, run the AI query, and report the timing."""


### PR DESCRIPTION
## Summary
- add repository root bootstrap logic to ai_test_query so direct execution resolves backend packages
- ensure ai_helpers adds the repo root to sys.path for consistent config imports

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d8b3ca1e64832b8a923354fa49242a