### PR TITLE
Add DOM text sanitization helper for lxml elements

### DIFF
--- a/backend/shop_handler/shop_handler.py
+++ b/backend/shop_handler/shop_handler.py
@@ -6,7 +6,6 @@ import json
 import logging
 import re
 import sys
-import unicodedata
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type
 
@@ -32,37 +31,19 @@ from automation.html_dom_finder import analyze as analyze_dom_report, sanitize_d
 from automation.html_invoice_helpers import parse_unknown_html_or_mhtml
 from automation.order_num_extract import extract_order_number
 
-from app.helpers import dict_to_tagged_text
+from app.helpers import (
+    DOM_WHITESPACE_NORMALIZATION_PATTERN,
+    clean_dom_text_fragment,
+    dict_to_tagged_text,
+)
 from app.search import find_code_matched_items
 
 log = logging.getLogger(__name__)
 
 
 # Collapse any run of whitespace into a single regular space so repeated spacing never leaks through.
-WHITESPACE_NORMALIZATION_PATTERN = re.compile(r"\s+")
-# Explicit list of non-breaking space characters that routinely appear in invoices and should be treated like standard spaces.
-_NON_BREAKING_SPACE_CHARACTERS = (" ", " ")
+WHITESPACE_NORMALIZATION_PATTERN = DOM_WHITESPACE_NORMALIZATION_PATTERN
 
-
-def _normalize_text_fragment(fragment: str) -> str:
-    """Sanitize raw text nodes to remove invisible characters and normalize spacing."""
-
-    cleaned_characters: List[str] = []
-    for character in fragment:
-        unicode_category = unicodedata.category(character)
-        if unicode_category == "Cf":
-            # Drop Unicode format characters (such as left-to-right marks) because they
-            # tend to sneak into invoices and break downstream parsing logic.
-            continue
-        if unicode_category.startswith("Z") or character in _NON_BREAKING_SPACE_CHARACTERS:
-            # Treat all Unicode space separator characters (including non-breaking variants)
-            # as ordinary spaces so words remain separated and formatting is consistent.
-            cleaned_characters.append(" ")
-            continue
-        cleaned_characters.append(character)
-
-    cleaned_fragment = "".join(cleaned_characters)
-    return cleaned_fragment
 
 class ShopHandler:
     """Base class for extracting store specific information from invoices."""
@@ -301,7 +282,7 @@ class ShopHandler:
 
                 # Remove invisible formatting characters and normalize internal spacing
                 # within the fragment before we consider adding it to the aggregate list.
-                cleaned_fragment = _normalize_text_fragment(fragment)
+                cleaned_fragment = clean_dom_text_fragment(fragment)
                 cleaned_fragment = WHITESPACE_NORMALIZATION_PATTERN.sub(" ", cleaned_fragment)
                 cleaned_fragment = cleaned_fragment.strip()
 


### PR DESCRIPTION
## Summary
- add reusable DOM whitespace normalization helpers in `app.helpers`, including `lxml_cell_text`
- update `ShopHandler` to consume the shared fragment sanitizer for consistent text extraction

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68da2dfd68a4832b8b872b42dc8bf1b7