### PR TITLE
Enable huge-tree HTML parsing for shop handlers

### DIFF
--- a/backend/shop_handler/amazon_handler.py
+++ b/backend/shop_handler/amazon_handler.py
@@ -155,8 +155,11 @@ class AmazonHandler(ShopHandler):
 
         final_url = response.url or final_url
 
+        # Parse the product page with a huge-tree capable parser to handle very large
+        # Amazon listings that sometimes include massive embedded tables or scripts.
+        parser = lxml_html.HTMLParser(huge_tree=True)
         try:
-            remote_root = lxml_html.fromstring(response.text)
+            remote_root = lxml_html.fromstring(response.text, parser=parser)
         except Exception:
             return final_url, final_name, description, product_code
 

--- a/backend/shop_handler/digikey_handler.py
+++ b/backend/shop_handler/digikey_handler.py
@@ -236,8 +236,11 @@ class DigiKeyHandler(ShopHandler):
         if not html_text:
             return ''
 
+        # Configure the HTML parser with huge_tree support so exceptionally large
+        # DigiKey product pages can be processed without triggering parser guards.
+        parser = lxml_html.HTMLParser(huge_tree=True)
         try:
-            root = lxml_html.fromstring(html_text)
+            root = lxml_html.fromstring(html_text, parser=parser)
         except Exception:
             return ''
 

--- a/backend/shop_handler/shop_handler.py
+++ b/backend/shop_handler/shop_handler.py
@@ -63,11 +63,14 @@ class ShopHandler:
         if not isinstance(raw_html, str) or not raw_html.strip():
             raise ValueError("HTML content must be a non-empty string.")
 
+        # Use an HTML parser configured for extremely large documents so that gigantic
+        # invoices never trigger lxml's security limits during ingestion.
+        parser = lxml_html.HTMLParser(huge_tree=True)
         try:
-            root = lxml_html.fromstring(raw_html)
+            root = lxml_html.fromstring(raw_html, parser=parser)
         except Exception as exc:
             log.debug("Falling back to HTML fragment parsing during ingestion: %s", exc)
-            root = lxml_html.fragment_fromstring(raw_html, create_parent=True)
+            root = lxml_html.fragment_fromstring(raw_html, create_parent=True, parser=parser)
 
         sanitized_root = sanitize_dom(root)
         sanitized_html = lxml_html.tostring(sanitized_root, encoding="unicode")


### PR DESCRIPTION
## Summary
- configure the shared shop handler ingestion to parse invoices with an lxml HTML parser that enables huge-tree support
- update the Amazon and DigiKey handlers to reuse the huge-tree parser when they fetch remote product pages
- add inline comments that explain the reasoning for enabling huge-tree parsing to avoid issues with massive HTML documents

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68da3a741c54832bbb4f05a4755a8e27