### PR TITLE
Extract email polling into Gmail and IMAP helper modules

### DIFF
--- a/backend/app/invoice_handlers.py
+++ b/backend/app/invoice_handlers.py
@@ -4,177 +4,26 @@ import json
 import logging
 import uuid
 from datetime import date, datetime, timezone
-from email.utils import parsedate_to_datetime
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from flask import Blueprint, jsonify, request, current_app
 from sqlalchemy import text
 from werkzeug.datastructures import FileStorage
 
-from automation.gmail_proc import (
-    extract_text_content,
-    get_full_message,
-    gmail_date_x_days_query,
-    list_message_ids,
-)
 from automation.order_num_extract import extract_order_number, extract_order_number_and_url
 from shop_handler import ShopHandler
 from automation.html_invoice_helpers import parse_mhtml_from_string, sniff_format
 from lxml import html as lxml_html
 from app.db import get_db_item_as_dict, get_engine, update_db_row_by_dict, unwrap_db_result
-from .config_loader import get_private_dir_path
 from .user_login import login_required
 from .job_manager import get_job_manager
+
+from backend.email.gmail import GmailChecker
+from backend.email.imap import ImapChecker
 
 bp = Blueprint("invoice_handlers", __name__, url_prefix="/api")
 
 log = logging.getLogger(__name__)
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SECRETS_PATH = REPO_ROOT / "config" / "secrets.json"
-
-
-def _gmail_token_path() -> Path:
-    """
-    Resolve the Gmail OAuth token cache location, honoring the optional private_dir hint.
-    """
-    private_dir = get_private_dir_path()
-    if private_dir is not None:
-        # Keep the token beside other private runtime artifacts when configured.
-        return Path(private_dir) / "gmail_token.json"
-    return SECRETS_PATH.with_name("gmail_token.json")
-
-
-def _load_gmail_token() -> Dict[str, Any]:
-    token_path = _gmail_token_path()
-
-    if token_path.exists():
-        raw_token = token_path.read_text(encoding="utf-8")
-        try:
-            token_data = json.loads(raw_token)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"Invalid JSON content in Gmail token file at {token_path}"
-            ) from exc
-        if not isinstance(token_data, dict):
-            raise ValueError("gmail_token.json must contain a JSON object with OAuth credentials")
-        return token_data
-
-    if not SECRETS_PATH.exists():
-        raise FileNotFoundError(f"Missing secrets file at {SECRETS_PATH}")
-
-    data = json.loads(SECRETS_PATH.read_text(encoding="utf-8"))
-    token = data.get("gmail_api_token")
-    if not isinstance(token, dict):
-        raise ValueError("gmail_api_token must be a JSON object containing OAuth credentials")
-    return token
-
-
-def _build_gmail_service() -> Any:
-    token_path = _gmail_token_path()
-    token_info = _load_gmail_token()
-
-    try:
-        from google.auth.transport.requests import Request
-        from google.oauth2.credentials import Credentials
-        from googleapiclient.discovery import build
-    except ImportError as exc:  # pragma: no cover - dependency provided in runtime env
-        raise RuntimeError("Google API client libraries are required to poll Gmail") from exc
-
-    scopes = token_info.get("scopes")
-    if not scopes:
-        scopes = ["https://www.googleapis.com/auth/gmail.readonly"]
-
-    creds = Credentials.from_authorized_user_info(token_info, scopes=scopes)
-
-    persist_token = not token_path.exists()
-
-    if not creds.valid:
-        if creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        persist_token = True
-
-    if persist_token:
-        token_path.parent.mkdir(parents=True, exist_ok=True)
-        token_path.write_text(creds.to_json(), encoding="utf-8")
-
-    return build("gmail", "v1", credentials=creds)
-
-
-def _fetch_seen_ids() -> Sequence[str]:
-    engine = get_engine()
-    try:
-        with engine.connect() as conn:
-            result = conn.execute(text("SELECT email_uuid FROM gmail_seen"))
-            return [str(row[0]) for row in result if row[0] is not None]
-    except Exception:
-        log.exception("Failed to load gmail_seen entries; treating as empty set")
-        return []
-
-
-def _normalize_gmail_id(message_id: Optional[str]) -> Optional[str]:
-    if not message_id:
-        return message_id
-
-    cleaned = message_id.strip()
-    hex_candidate = cleaned.replace("-", "")
-    hex_chars = set("0123456789abcdefABCDEF")
-    if 16 <= len(hex_candidate) <= 32 and set(hex_candidate).issubset(hex_chars):
-        try:
-            padded = hex_candidate.rjust(32, "0")
-            return str(uuid.UUID(padded))
-        except Exception:
-            log.debug("Message id %s looked hex-like but failed UUID normalization", message_id)
-    return cleaned
-
-
-def _determine_lookback_days() -> int:
-    engine = get_engine()
-    try:
-        with engine.connect() as conn:
-            row = conn.execute(
-                text("SELECT date_seen FROM gmail_seen ORDER BY date_seen DESC LIMIT 1")
-            ).first()
-    except Exception:
-        log.exception("Failed to query gmail_seen for last seen date; defaulting to 7 days")
-        return 7
-
-    if not row or not row[0]:
-        return 7
-
-    last_seen = row[0]
-    if isinstance(last_seen, datetime):
-        last_dt = last_seen
-    elif isinstance(last_seen, date):
-        last_dt = datetime.combine(last_seen, datetime.min.time(), tzinfo=timezone.utc)
-    else:
-        last_dt = datetime.now(timezone.utc)
-
-    if last_dt.tzinfo is None:
-        last_dt = last_dt.replace(tzinfo=timezone.utc)
-
-    now = datetime.now(timezone.utc)
-    days_since = max(0, (now - last_dt).days)
-    return days_since + 7
-
-
-def _parse_email_date(header_value: Optional[str]) -> datetime:
-    if not header_value:
-        return datetime.now(timezone.utc)
-
-    try:
-        parsed = parsedate_to_datetime(header_value)
-    except (TypeError, ValueError):
-        parsed = None
-
-    if parsed is None:
-        return datetime.now(timezone.utc)
-
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
-
 
 def _serialize_invoice_row(row: Dict[str, Any]) -> Dict[str, Any]:
     data = dict(row)
@@ -192,120 +41,6 @@ def _serialize_invoice_row(row: Dict[str, Any]) -> Dict[str, Any]:
             except Exception:
                 pass
     return data
-
-def _handle_gmail_message(msg: Dict[str, Any]) -> Dict[str, Any]:
-    headers = {h.get("name", "").lower(): h.get("value", "") for h in msg.get("payload", {}).get("headers", [])}
-    subject = headers.get("subject", "")
-    message_id = msg.get("id")
-    normalized_id = _normalize_gmail_id(message_id)
-
-    content = extract_text_content(msg.get("payload", {}))
-    html_body = content.get("html") or ""
-    text_body = content.get("text") or ""
-
-    order_number = None
-    order_url = None
-    if subject:
-        order_number = extract_order_number(subject)
-    if not order_number and html_body:
-        order_number, order_url = extract_order_number_and_url(html_body)
-    if not order_number:
-        order_number = extract_order_number(text_body)
-
-    if order_number:
-        order_number = order_number.strip()
-
-    email_date = _parse_email_date(headers.get("date"))
-
-    invoice_id: Optional[str] = None
-    invoice_error: Optional[str] = None
-
-    handler: Optional[ShopHandler] = None
-    auto_summary = "[]"
-    if html_body:
-        try:
-            handler = ShopHandler.ingest_html(html_body)
-            auto_summary = handler.build_auto_summary()
-        except Exception:
-            log.exception("Failed to generate auto-summary using shop handler for Gmail message")
-            handler = None
-            auto_summary = "[]"
-
-    if not order_number and handler is not None:
-        handler_order_number = handler.get_order_number()
-        if handler_order_number:
-            order_number = handler_order_number.strip()
-
-    if order_number:
-        gmail_url = f"https://mail.google.com/mail/u/0/#all/{message_id}"
-        urls_value = gmail_url
-        if order_url:
-            urls_value = f"{urls_value};{order_url}"
-
-        invoice_payload: Dict[str, Any] = {
-            "date": email_date,
-            "order_number": order_number,
-            "shop_name": handler.get_shop_name() if handler else "",
-            "urls": urls_value,
-            "subject": subject,
-            "html": html_body or text_body,
-            "notes": "",
-            "has_been_processed": False,
-            "auto_summary": auto_summary,
-            "snooze": datetime.now(timezone.utc),
-            "is_deleted": False,
-        }
-
-        engine = get_engine()
-        (
-            invoice_status,
-            invoice_failed,
-            _invoice_reply,
-            invoice_row,
-            invoice_pk,
-            invoice_message,
-        ) = unwrap_db_result(
-            update_db_row_by_dict(engine, "invoices", "new", invoice_payload, fuzzy=False)
-        )
-        if invoice_failed:
-            invoice_error = invoice_message
-            log.error("Failed to insert invoice for Gmail message %s: %s", message_id, invoice_message)
-        else:
-            invoice_id = invoice_pk or invoice_row.get("id")
-
-    gmail_payload: Dict[str, Any] = {
-        "email_uuid": normalized_id or message_id,
-        "date_seen": email_date,
-    }
-    if invoice_id:
-        gmail_payload["invoice_id"] = invoice_id
-
-    engine = get_engine()
-    (
-        gmail_status,
-        gmail_failed,
-        _gmail_reply,
-        _gmail_row,
-        _gmail_pk,
-        gmail_message,
-    ) = unwrap_db_result(
-        update_db_row_by_dict(engine, "gmail_seen", "new", gmail_payload, fuzzy=False)
-    )
-    if gmail_failed:
-        log.error("Failed to insert gmail_seen row for message %s: %s", message_id, gmail_message)
-
-    status = "invoice_created" if invoice_id else ("invoice_failed" if invoice_error else "no_order_number")
-
-    return {
-        "message_id": message_id,
-        "normalized_id": normalized_id,
-        "order_number": order_number,
-        "invoice_id": invoice_id,
-        "email_date": email_date.isoformat(),
-        "invoice_error": invoice_error,
-        "gmail_status": gmail_status,
-        "status": status,
-    }
 
 def _ingest_invoice_file(file_storage: FileStorage) -> Dict[str, Any]:
     """Prepare metadata for a single uploaded invoice/email file."""
@@ -556,59 +291,21 @@ def set_invoice_api() -> Any:
 
 
 def check_email_task(_context: Dict[str, Any]) -> Dict[str, Any]:
+    """Coordinate mailbox polling across supported providers."""
     log.info("Mailbox check requested")
-    try:
-        service = _build_gmail_service()
-    except Exception as exc:
-        log.exception("Unable to initialise Gmail client")
-        raise RuntimeError("Failed to initialise Gmail client.") from exc
-
-    lookback_days = _determine_lookback_days()
-    query = gmail_date_x_days_query(lookback_days)
-
-    try:
-        message_ids = list_message_ids(service, query)
-    except Exception as exc:
-        log.exception("Unable to list Gmail messages for query %s", query)
-        raise RuntimeError("Failed to query Gmail.") from exc
-
-    seen_ids = list(_fetch_seen_ids())
-    seen_normalized = {_normalize_gmail_id(value) for value in seen_ids if value}
-
-    new_ids: List[str] = []
-    for mid in message_ids:
-        normalized = _normalize_gmail_id(mid)
-        if mid in seen_ids or (normalized and normalized in seen_normalized):
-            continue
-        new_ids.append(mid)
-
-    processed: List[Dict[str, Any]] = []
-    for mid in new_ids:
-        try:
-            msg = get_full_message(service, mid)
-        except Exception as exc:
-            log.exception("Failed to fetch Gmail message %s", mid)
-            processed.append({"message_id": mid, "status": "fetch_error", "error": str(exc)})
-            continue
-
-        try:
-            result = _handle_gmail_message(msg)
-            processed.append(result)
-        except Exception as exc:
-            log.exception("Failed to process Gmail message %s", mid)
-            processed.append({"message_id": mid, "status": "processing_error", "error": str(exc)})
-
-    summary = {
-        "ok": True,
-        "queried_days": lookback_days,
-        "query": query,
-        "checked": len(message_ids),
-        "new_messages": len(new_ids),
-        "processed": processed,
+    # Gather Gmail updates first so any OAuth errors are reported promptly.
+    gmail_summary = GmailChecker.check_email()
+    # Poll the configured IMAP mailbox next; this may be skipped when unconfigured.
+    imap_summary = ImapChecker.check_email()
+    overall_ok = True
+    for summary in (gmail_summary, imap_summary):
+        if isinstance(summary, dict) and not summary.get("ok", True):
+            overall_ok = False
+    return {
+        "ok": overall_ok,
+        "gmail": gmail_summary,
+        "imap": imap_summary,
     }
-
-    return summary
-
 
 def _invoice_upload_task(context: Dict[str, Any]) -> Dict[str, Any]:
     files = context.get("files")

--- a/backend/email/__init__.py
+++ b/backend/email/__init__.py
@@ -1,0 +1,7 @@
+# backend/email/__init__.py
+"""Helper classes for polling external mailboxes."""
+
+from .gmail import GmailChecker
+from .imap import ImapChecker
+
+__all__ = ["GmailChecker", "ImapChecker"]

--- a/backend/email/email_helper.py
+++ b/backend/email/email_helper.py
@@ -1,0 +1,236 @@
+# backend/email/email_helper.py
+"""Shared helpers for mailbox polling implementations."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from sqlalchemy import text
+
+from automation.order_num_extract import extract_order_number, extract_order_number_and_url
+from shop_handler import ShopHandler
+from app.db import get_engine, update_db_row_by_dict, unwrap_db_result
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SECRETS_PATH = REPO_ROOT / "config" / "secrets.json"
+
+log = logging.getLogger(__name__)
+
+
+class EmailChecker:
+    """Simple base class used by concrete mailbox polling helpers."""
+
+    @staticmethod
+    def check_email() -> Dict[str, Any]:
+        """Subclasses must provide a polling implementation."""
+        raise NotImplementedError("Subclasses must implement check_email().")
+
+    @staticmethod
+    def secrets_path() -> Path:
+        """Return the expected location of config/secrets.json."""
+        return SECRETS_PATH
+
+    @staticmethod
+    def load_secrets() -> Dict[str, Any]:
+        """Load secrets.json when available, returning an empty mapping on failure."""
+        path = EmailChecker.secrets_path()
+        if not path.exists():
+            log.info("No secrets.json found at %s; skipping credential-dependent checks.", path)
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            log.exception("Unable to parse secrets file at %s; treating as empty.", path)
+            return {}
+        if not isinstance(data, dict):
+            log.warning("Expected %s to contain a JSON object; ignoring malformed content.", path)
+            return {}
+        return data
+
+    @staticmethod
+    def build_summary(
+        provider: str,
+        lookback_days: int,
+        query: Optional[str],
+        checked: int,
+        new_messages: int,
+        processed: Optional[list],
+        *,
+        ok: bool = True,
+        skipped: bool = False,
+        reason: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a consistent summary payload for API responses."""
+        summary = {
+            "provider": provider,
+            "ok": ok,
+            "skipped": skipped,
+            "reason": reason,
+            "error": error,
+            "queried_days": lookback_days,
+            "query": query,
+            "checked": checked,
+            "new_messages": new_messages,
+            "processed": processed or [],
+        }
+        return summary
+
+    @staticmethod
+    def determine_lookback_days(table_name: str) -> int:
+        """Determine how many days of history should be polled for a mailbox."""
+        engine = get_engine()
+        try:
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text(f"SELECT date_seen FROM {table_name} ORDER BY date_seen DESC LIMIT 1")
+                ).first()
+        except Exception:
+            log.exception("Failed to query %s for last seen date; defaulting to 7 days", table_name)
+            return 7
+        if not row or not row[0]:
+            return 7
+        last_seen = row[0]
+        if isinstance(last_seen, datetime):
+            last_dt = last_seen
+        elif isinstance(last_seen, date):
+            last_dt = datetime.combine(last_seen, datetime.min.time(), tzinfo=timezone.utc)
+        else:
+            last_dt = datetime.now(timezone.utc)
+        if last_dt.tzinfo is None:
+            last_dt = last_dt.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        days_since = max(0, (now - last_dt).days)
+        return days_since + 7
+
+    @staticmethod
+    def parse_email_date(header_value: Optional[str]) -> datetime:
+        """Parse an email Date header into a timezone-aware datetime."""
+        if not header_value:
+            return datetime.now(timezone.utc)
+        from email.utils import parsedate_to_datetime
+
+        try:
+            parsed = parsedate_to_datetime(header_value)
+        except (TypeError, ValueError):
+            parsed = None
+        if parsed is None:
+            return datetime.now(timezone.utc)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def ingest_invoice_from_email(
+        provider_label: str,
+        message_id: Optional[str],
+        subject: str,
+        email_date: datetime,
+        html_body: str,
+        text_body: str,
+        primary_url: Optional[str],
+        secondary_url: Optional[str],
+    ) -> Dict[str, Any]:
+        """Create or update an invoice row from parsed email content."""
+        order_number: Optional[str] = None
+        derived_order_url: Optional[str] = None
+        if subject:
+            order_number = extract_order_number(subject)
+        if not order_number and html_body:
+            order_number, derived_order_url = extract_order_number_and_url(html_body)
+        if not order_number and text_body:
+            order_number = extract_order_number(text_body)
+        if secondary_url is None and derived_order_url:
+            secondary_url = derived_order_url
+        if order_number:
+            order_number = order_number.strip()
+        handler: Optional[ShopHandler] = None
+        auto_summary = "[]"
+        if html_body:
+            try:
+                handler = ShopHandler.ingest_html(html_body)
+                auto_summary = handler.build_auto_summary()
+            except Exception:
+                log.exception(
+                    "Failed to build auto-summary for %s message %s",
+                    provider_label,
+                    message_id,
+                )
+                handler = None
+                auto_summary = "[]"
+        if not order_number and handler is not None:
+            handler_order = handler.get_order_number()
+            if handler_order:
+                order_number = handler_order.strip()
+        invoice_id = None
+        invoice_error: Optional[str] = None
+        if order_number:
+            url_parts = []
+            if primary_url:
+                url_parts.append(primary_url)
+            if secondary_url:
+                url_parts.append(secondary_url)
+            urls_value = ";".join(part for part in url_parts if part)
+            engine = get_engine()
+            invoice_payload: Dict[str, Any] = {
+                "date": email_date,
+                "order_number": order_number,
+                "shop_name": handler.get_shop_name() if handler else "",
+                "urls": urls_value,
+                "subject": subject,
+                "html": html_body or text_body,
+                "notes": "",
+                "has_been_processed": False,
+                "auto_summary": auto_summary,
+                "snooze": datetime.now(timezone.utc),
+                "is_deleted": False,
+            }
+            try:
+                update_result = update_db_row_by_dict(
+                    engine,
+                    "invoices",
+                    "new",
+                    invoice_payload,
+                    fuzzy=False,
+                )
+                (
+                    _status,
+                    failed,
+                    _reply,
+                    invoice_row,
+                    invoice_pk,
+                    message,
+                ) = unwrap_db_result(update_result)
+            except Exception as exc:
+                log.exception(
+                    "Failed to insert invoice for %s message %s",
+                    provider_label,
+                    message_id,
+                )
+                invoice_error = str(exc)
+            else:
+                if failed:
+                    invoice_error = message if isinstance(message, str) else str(message)
+                    log.error(
+                        "Failed to insert invoice for %s message %s: %s",
+                        provider_label,
+                        message_id,
+                        invoice_error,
+                    )
+                else:
+                    invoice_id = invoice_pk or (
+                        invoice_row.get("id") if isinstance(invoice_row, dict) else None
+                    )
+        status = "invoice_created" if invoice_id else (
+            "invoice_failed" if invoice_error else "no_order_number"
+        )
+        return {
+            "order_number": order_number,
+            "invoice_id": invoice_id,
+            "invoice_error": invoice_error,
+            "status": status,
+        }

--- a/backend/email/gmail.py
+++ b/backend/email/gmail.py
@@ -1,0 +1,274 @@
+# backend/email/gmail.py
+"""Gmail-specific mailbox polling implementation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from sqlalchemy import text
+
+from automation.gmail_proc import (
+    extract_text_content,
+    get_full_message,
+    gmail_date_x_days_query,
+    list_message_ids,
+)
+from backend.app.config_loader import get_private_dir_path
+from app.db import get_engine, update_db_row_by_dict, unwrap_db_result
+
+from .email_helper import EmailChecker
+
+log = logging.getLogger(__name__)
+
+
+class GmailChecker(EmailChecker):
+    """Poll Gmail for recent order confirmations and create invoices."""
+
+    @staticmethod
+    def _gmail_token_path() -> Path:
+        """Resolve the Gmail OAuth token cache location."""
+        private_dir = get_private_dir_path()
+        if private_dir is not None:
+            return Path(private_dir) / "gmail_token.json"
+        return EmailChecker.secrets_path().with_name("gmail_token.json")
+
+    @staticmethod
+    def _load_gmail_token() -> Optional[Dict[str, Any]]:
+        """Load cached Gmail OAuth details from disk or secrets.json."""
+        token_path = GmailChecker._gmail_token_path()
+        if token_path.exists():
+            raw_token = token_path.read_text(encoding="utf-8")
+            try:
+                token_data = json.loads(raw_token)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON content in Gmail token file at {token_path}"
+                ) from exc
+            if not isinstance(token_data, dict):
+                raise ValueError("gmail_token.json must contain a JSON object with OAuth credentials")
+            return token_data
+        secrets = EmailChecker.load_secrets()
+        token = secrets.get("gmail_api_token")
+        if isinstance(token, dict):
+            return token
+        return None
+
+    @staticmethod
+    def is_configured() -> bool:
+        """Return True when Gmail credentials are present."""
+        try:
+            token_path = GmailChecker._gmail_token_path()
+            if token_path.exists():
+                return True
+            secrets = EmailChecker.load_secrets()
+            token = secrets.get("gmail_api_token")
+            return isinstance(token, dict) and bool(token)
+        except Exception:
+            log.exception("Error while checking Gmail configuration; assuming Gmail is unavailable.")
+            return False
+
+    @staticmethod
+    def _build_gmail_service() -> Any:
+        """Initialise the Gmail API service client."""
+        token_info = GmailChecker._load_gmail_token()
+        if not token_info:
+            raise RuntimeError("Gmail credentials are not configured.")
+        token_path = GmailChecker._gmail_token_path()
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2.credentials import Credentials
+            from googleapiclient.discovery import build
+        except ImportError as exc:  # pragma: no cover - dependency provided in runtime env
+            raise RuntimeError("Google API client libraries are required to poll Gmail") from exc
+        scopes = token_info.get("scopes") or ["https://www.googleapis.com/auth/gmail.readonly"]
+        creds = Credentials.from_authorized_user_info(token_info, scopes=scopes)
+        persist_token = not token_path.exists()
+        if not creds.valid:
+            if creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            persist_token = True
+        if persist_token:
+            token_path.parent.mkdir(parents=True, exist_ok=True)
+            token_path.write_text(creds.to_json(), encoding="utf-8")
+        return build("gmail", "v1", credentials=creds)
+
+    @staticmethod
+    def _fetch_seen_ids() -> Sequence[str]:
+        """Retrieve Gmail message identifiers that were already processed."""
+        engine = get_engine()
+        try:
+            with engine.connect() as conn:
+                result = conn.execute(text("SELECT email_uuid FROM gmail_seen"))
+                return [str(row[0]) for row in result if row[0] is not None]
+        except Exception:
+            log.exception("Failed to load gmail_seen entries; treating as empty set")
+            return []
+
+    @staticmethod
+    def _normalize_gmail_id(message_id: Optional[str]) -> Optional[str]:
+        """Convert Gmail message identifiers into canonical UUID format when possible."""
+        if not message_id:
+            return message_id
+        cleaned = message_id.strip()
+        hex_candidate = cleaned.replace("-", "")
+        hex_chars = set("0123456789abcdefABCDEF")
+        if 16 <= len(hex_candidate) <= 32 and set(hex_candidate).issubset(hex_chars):
+            try:
+                padded = hex_candidate.rjust(32, "0")
+                return str(uuid.UUID(padded))
+            except Exception:
+                log.debug("Message id %s looked hex-like but failed UUID normalization", message_id)
+        return cleaned
+
+    @staticmethod
+    def _handle_gmail_message(msg: Dict[str, Any]) -> Dict[str, Any]:
+        """Process a Gmail API message and create or update invoice rows."""
+        headers = {
+            h.get("name", "").lower(): h.get("value", "")
+            for h in msg.get("payload", {}).get("headers", [])
+        }
+        subject = headers.get("subject", "")
+        message_id = msg.get("id") or ""
+        normalized_id = GmailChecker._normalize_gmail_id(message_id)
+        content = extract_text_content(msg.get("payload", {}))
+        html_body = content.get("html") or ""
+        text_body = content.get("text") or ""
+        email_date = EmailChecker.parse_email_date(headers.get("date"))
+        gmail_link = f"https://mail.google.com/mail/u/0/#all/{message_id}" if message_id else None
+        ingestion = EmailChecker.ingest_invoice_from_email(
+            "gmail",
+            message_id,
+            subject,
+            email_date,
+            html_body,
+            text_body,
+            gmail_link,
+            None,
+        )
+        gmail_payload: Dict[str, Any] = {
+            "email_uuid": normalized_id or message_id,
+            "date_seen": email_date,
+        }
+        if ingestion.get("invoice_id"):
+            gmail_payload["invoice_id"] = ingestion["invoice_id"]
+        engine = get_engine()
+        (
+            gmail_status,
+            gmail_failed,
+            _gmail_reply,
+            _gmail_row,
+            _gmail_pk,
+            gmail_message,
+        ) = unwrap_db_result(
+            update_db_row_by_dict(engine, "gmail_seen", "new", gmail_payload, fuzzy=False)
+        )
+        if gmail_failed:
+            log.error(
+                "Failed to insert gmail_seen row for message %s: %s",
+                message_id,
+                gmail_message,
+            )
+        invoice_id = ingestion.get("invoice_id")
+        return {
+            "message_id": message_id,
+            "normalized_id": normalized_id,
+            "order_number": ingestion.get("order_number"),
+            "invoice_id": str(invoice_id) if invoice_id is not None else None,
+            "email_date": email_date.isoformat(),
+            "invoice_error": ingestion.get("invoice_error"),
+            "gmail_status": gmail_status,
+            "status": ingestion.get("status"),
+        }
+
+    @staticmethod
+    def check_email() -> Dict[str, Any]:
+        """Poll Gmail for new messages and build a processing summary."""
+        if not GmailChecker.is_configured():
+            return EmailChecker.build_summary(
+                "gmail",
+                0,
+                None,
+                0,
+                0,
+                [],
+                skipped=True,
+                reason="Gmail credentials are not configured.",
+            )
+        lookback_days = EmailChecker.determine_lookback_days("gmail_seen")
+        query = gmail_date_x_days_query(lookback_days)
+        try:
+            service = GmailChecker._build_gmail_service()
+        except Exception as exc:
+            log.exception("Unable to initialise Gmail client")
+            return EmailChecker.build_summary(
+                "gmail",
+                lookback_days,
+                query,
+                0,
+                0,
+                [],
+                ok=False,
+                error=str(exc),
+            )
+        try:
+            message_ids = list_message_ids(service, query)
+        except Exception as exc:
+            log.exception("Unable to list Gmail messages for query %s", query)
+            return EmailChecker.build_summary(
+                "gmail",
+                lookback_days,
+                query,
+                0,
+                0,
+                [],
+                ok=False,
+                error=str(exc),
+            )
+        seen_ids = list(GmailChecker._fetch_seen_ids())
+        seen_normalized = {
+            GmailChecker._normalize_gmail_id(value) for value in seen_ids if value
+        }
+        new_ids: List[str] = []
+        for mid in message_ids:
+            normalized = GmailChecker._normalize_gmail_id(mid)
+            if mid in seen_ids or (normalized and normalized in seen_normalized):
+                continue
+            new_ids.append(mid)
+        processed: List[Dict[str, Any]] = []
+        for mid in new_ids:
+            try:
+                msg = get_full_message(service, mid)
+            except Exception as exc:
+                log.exception("Failed to fetch Gmail message %s", mid)
+                processed.append(
+                    {
+                        "message_id": mid,
+                        "status": "fetch_error",
+                        "error": str(exc),
+                    }
+                )
+                continue
+            try:
+                result = GmailChecker._handle_gmail_message(msg)
+                processed.append(result)
+            except Exception as exc:
+                log.exception("Failed to process Gmail message %s", mid)
+                processed.append(
+                    {
+                        "message_id": mid,
+                        "status": "processing_error",
+                        "error": str(exc),
+                    }
+                )
+        return EmailChecker.build_summary(
+            "gmail",
+            lookback_days,
+            query,
+            len(message_ids),
+            len(new_ids),
+            processed,
+        )

--- a/backend/email/imap.py
+++ b/backend/email/imap.py
@@ -1,0 +1,305 @@
+# backend/email/imap.py
+"""Generic IMAP mailbox polling implementation."""
+
+from __future__ import annotations
+
+import imaplib
+import logging
+from datetime import datetime, timedelta, timezone
+from email import message_from_bytes
+from email.header import decode_header, make_header
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import text
+
+from app.db import get_engine, update_db_row_by_dict, unwrap_db_result
+
+from .email_helper import EmailChecker
+
+log = logging.getLogger(__name__)
+
+
+class ImapChecker(EmailChecker):
+    """Poll a traditional IMAP inbox for recent order confirmations."""
+
+    _CONFIG_KEY = "imap_mail"
+
+    @staticmethod
+    def _load_settings() -> Optional[Dict[str, Any]]:
+        """Load IMAP connection details from secrets.json."""
+        secrets = EmailChecker.load_secrets()
+        config = secrets.get(ImapChecker._CONFIG_KEY)
+        if not isinstance(config, dict):
+            return None
+        required_keys = ("host", "username", "password")
+        for key in required_keys:
+            value = config.get(key)
+            if not isinstance(value, str) or not value.strip():
+                log.warning("IMAP configuration missing required key %s", key)
+                return None
+        return config
+
+    @staticmethod
+    def is_configured() -> bool:
+        """Indicate whether IMAP credentials are available."""
+        return ImapChecker._load_settings() is not None
+
+    @staticmethod
+    def _bool_setting(value: Any, default: bool = True) -> bool:
+        """Convert loosely-typed configuration values into booleans."""
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        text_value = str(value).strip().lower()
+        if text_value in {"1", "true", "yes", "on"}:
+            return True
+        if text_value in {"0", "false", "no", "off"}:
+            return False
+        return default
+
+    @staticmethod
+    def _connect(settings: Dict[str, Any]) -> imaplib.IMAP4:
+        """Establish an IMAP connection using the supplied settings."""
+        host = settings.get("host")
+        port = settings.get("port")
+        use_ssl = ImapChecker._bool_setting(settings.get("use_ssl"), True)
+        if isinstance(port, str) and port.strip():
+            try:
+                port_value = int(port)
+            except ValueError:
+                port_value = 993 if use_ssl else 143
+        elif isinstance(port, (int, float)):
+            port_value = int(port)
+        else:
+            port_value = 993 if use_ssl else 143
+        if use_ssl:
+            client: imaplib.IMAP4 = imaplib.IMAP4_SSL(host, port_value)
+        else:
+            client = imaplib.IMAP4(host, port_value)
+        client.login(settings.get("username"), settings.get("password"))
+        mailbox = settings.get("mailbox") or "INBOX"
+        client.select(mailbox)
+        return client
+
+    @staticmethod
+    def _fetch_seen_uids() -> Sequence[str]:
+        """Fetch IMAP UIDs that were already processed."""
+        engine = get_engine()
+        try:
+            with engine.connect() as conn:
+                result = conn.execute(text("SELECT email_uuid FROM imail_seen"))
+                seen: List[str] = []
+                for row in result:
+                    value = row[0]
+                    if isinstance(value, memoryview):
+                        value = value.tobytes()
+                    if isinstance(value, bytes):
+                        seen.append(value.decode("utf-8", errors="ignore"))
+                    elif value is not None:
+                        seen.append(str(value))
+                return seen
+        except Exception:
+            log.exception("Failed to load imail_seen entries; treating as empty set")
+            return []
+
+    @staticmethod
+    def _decode_header_value(raw_value: Optional[str]) -> str:
+        """Decode MIME-encoded header values into readable text."""
+        if not raw_value:
+            return ""
+        try:
+            decoded = str(make_header(decode_header(raw_value)))
+            return decoded
+        except Exception:
+            log.exception("Failed to decode header value %r", raw_value)
+            return str(raw_value)
+
+    @staticmethod
+    def _extract_bodies(msg) -> Tuple[str, str]:
+        """Extract text and HTML parts from an email message."""
+        html_body = ""
+        text_body = ""
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.is_multipart():
+                    continue
+                disposition = part.get("Content-Disposition", "")
+                if disposition and "attachment" in disposition.lower():
+                    continue
+                payload = part.get_payload(decode=True)
+                if not payload:
+                    continue
+                charset = part.get_content_charset() or "utf-8"
+                try:
+                    decoded = payload.decode(charset, errors="replace")
+                except Exception:
+                    decoded = payload.decode("utf-8", errors="replace")
+                content_type = part.get_content_type()
+                if content_type == "text/html" and not html_body:
+                    html_body = decoded
+                elif content_type == "text/plain" and not text_body:
+                    text_body = decoded
+        else:
+            payload = msg.get_payload(decode=True)
+            if payload:
+                charset = msg.get_content_charset() or "utf-8"
+                try:
+                    decoded = payload.decode(charset, errors="replace")
+                except Exception:
+                    decoded = payload.decode("utf-8", errors="replace")
+                if msg.get_content_type() == "text/html":
+                    html_body = decoded
+                else:
+                    text_body = decoded
+        return html_body, text_body
+
+    @staticmethod
+    def _handle_imap_message(uid: str, msg_bytes: bytes) -> Dict[str, Any]:
+        """Process a raw IMAP message payload."""
+        msg = message_from_bytes(msg_bytes)
+        subject = ImapChecker._decode_header_value(msg.get("Subject"))
+        message_id = ImapChecker._decode_header_value(msg.get("Message-ID")) or uid
+        html_body, text_body = ImapChecker._extract_bodies(msg)
+        email_date = EmailChecker.parse_email_date(msg.get("Date"))
+        ingestion = EmailChecker.ingest_invoice_from_email(
+            "imap",
+            message_id,
+            subject,
+            email_date,
+            html_body,
+            text_body,
+            None,
+            None,
+        )
+        payload: Dict[str, Any] = {
+            "email_uuid": uid.encode("utf-8"),
+            "date_seen": email_date,
+        }
+        invoice_id = ingestion.get("invoice_id")
+        if invoice_id is not None:
+            payload["invoice_id"] = invoice_id
+        engine = get_engine()
+        (
+            imap_status,
+            imap_failed,
+            _imap_reply,
+            _imap_row,
+            _imap_pk,
+            imap_message,
+        ) = unwrap_db_result(
+            update_db_row_by_dict(engine, "imail_seen", "new", payload, fuzzy=False)
+        )
+        if imap_failed:
+            log.error("Failed to insert imail_seen row for UID %s: %s", uid, imap_message)
+        return {
+            "uid": uid,
+            "message_id": message_id,
+            "order_number": ingestion.get("order_number"),
+            "invoice_id": str(invoice_id) if invoice_id is not None else None,
+            "email_date": email_date.isoformat(),
+            "invoice_error": ingestion.get("invoice_error"),
+            "imap_status": imap_status,
+            "status": ingestion.get("status"),
+        }
+
+    @staticmethod
+    def check_email() -> Dict[str, Any]:
+        """Poll the configured IMAP mailbox for new emails."""
+        settings = ImapChecker._load_settings()
+        if not settings:
+            return EmailChecker.build_summary(
+                "imap",
+                0,
+                None,
+                0,
+                0,
+                [],
+                skipped=True,
+                reason="IMAP credentials are not configured.",
+            )
+        lookback_days = EmailChecker.determine_lookback_days("imail_seen")
+        since_date = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+        query = f"(SINCE {since_date.strftime('%d-%b-%Y')})"
+        try:
+            client = ImapChecker._connect(settings)
+        except Exception as exc:
+            log.exception("Unable to initialise IMAP client")
+            return EmailChecker.build_summary(
+                "imap",
+                lookback_days,
+                query,
+                0,
+                0,
+                [],
+                ok=False,
+                error=str(exc),
+            )
+        try:
+            status, data = client.uid("search", None, query)
+            if status != "OK":
+                raise RuntimeError(f"IMAP search failed with status {status}")
+            raw_ids = data[0].split() if data and data[0] else []
+            uids = [uid.decode("utf-8", errors="ignore") for uid in raw_ids]
+        except Exception as exc:
+            log.exception("Unable to list IMAP messages for query %s", query)
+            try:
+                client.logout()
+            except Exception:
+                log.debug("IMAP logout raised an exception after search failure", exc_info=True)
+            return EmailChecker.build_summary(
+                "imap",
+                lookback_days,
+                query,
+                0,
+                0,
+                [],
+                ok=False,
+                error=str(exc),
+            )
+        seen_uids = set(ImapChecker._fetch_seen_uids())
+        new_uids = [uid for uid in uids if uid not in seen_uids]
+        processed: List[Dict[str, Any]] = []
+        for uid in new_uids:
+            try:
+                status, data = client.uid("fetch", uid, "(RFC822)")
+                if status != "OK" or not data:
+                    raise RuntimeError(f"IMAP fetch for UID {uid} failed with status {status}")
+                parts = [part[1] for part in data if isinstance(part, tuple) and part[1]]
+                msg_bytes = b"".join(parts)
+                if not msg_bytes:
+                    raise RuntimeError(f"No RFC822 payload returned for UID {uid}")
+            except Exception as exc:
+                log.exception("Failed to fetch IMAP message %s", uid)
+                processed.append(
+                    {
+                        "uid": uid,
+                        "status": "fetch_error",
+                        "error": str(exc),
+                    }
+                )
+                continue
+            try:
+                result = ImapChecker._handle_imap_message(uid, msg_bytes)
+                processed.append(result)
+            except Exception as exc:
+                log.exception("Failed to process IMAP message %s", uid)
+                processed.append(
+                    {
+                        "uid": uid,
+                        "status": "processing_error",
+                        "error": str(exc),
+                    }
+                )
+        try:
+            client.logout()
+        except Exception:
+            log.debug("IMAP logout raised an exception", exc_info=True)
+        return EmailChecker.build_summary(
+            "imap",
+            lookback_days,
+            query,
+            len(uids),
+            len(new_uids),
+            processed,
+        )

--- a/config/secrets.json.example
+++ b/config/secrets.json.example
@@ -26,5 +26,13 @@
     "universe_domain": "ghhmncaxir.bbo",
     "account": "",
     "expiry": "0537-98-50Q87:87:79.320311Q"
+  },
+  "imap_mail": {
+    "host": "imap.example.com",
+    "port": 993,
+    "username": "orders@example.com",
+    "password": "example-password",
+    "mailbox": "INBOX",
+    "use_ssl": true
   }
 }


### PR DESCRIPTION
## Summary
- move the Gmail polling implementation out of `invoice_handlers` and into a reusable `GmailChecker` that relies on shared helpers
- add an `ImapChecker` that reads credentials from `secrets.json`, records processed UIDs in `imail_seen`, and returns structured summaries
- update `check_email_task` to aggregate the Gmail and IMAP results and document sample IMAP credentials in `secrets.json.example`

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dafee46818832bb8640026ebea3c72