### PR TITLE
Implement bulk relationship endpoints

### DIFF
--- a/backend/app/invoice_handlers.py
+++ b/backend/app/invoice_handlers.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from flask import Blueprint, jsonify, request, current_app
-from sqlalchemy import text
+from sqlalchemy import text, bindparam
 from werkzeug.datastructures import FileStorage
 
 from automation.order_num_extract import extract_order_number, extract_order_number_and_url
@@ -17,6 +17,7 @@ from lxml import html as lxml_html
 from app.db import get_db_item_as_dict, get_engine, update_db_row_by_dict, unwrap_db_result
 from .user_login import login_required
 from .job_manager import get_job_manager
+from .helpers import normalize_pg_uuid
 
 from backend.email.gmail import GmailChecker
 from backend.email.imap import ImapChecker
@@ -593,3 +594,185 @@ def analyze_invoice_html() -> Any:
         return jsonify({"ok": False, "error": str(exc)}), 503
 
     return jsonify({"job_id": job_id})
+
+
+@bp.route("/invoicesassociations", methods=["POST"])
+@login_required
+def bulk_link_invoices_api() -> Any:
+    payload = request.get_json(silent=True) or {}
+    table_name = str(payload.get("table") or "invoices").strip().lower()
+    if table_name != "invoices":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "Only invoice associations are supported by this endpoint.",
+                }
+            ),
+            400,
+        )
+
+    target_uuid = payload.get("target_uuid")
+    if not target_uuid:
+        return jsonify({"ok": False, "error": "Missing target UUID."}), 400
+
+    try:
+        normalized_target = normalize_pg_uuid(str(target_uuid))
+    except Exception as exc:
+        log.debug("bulk_link_invoices_api: invalid target UUID %r: %s", target_uuid, exc)
+        return jsonify({"ok": False, "error": "Invalid target UUID."}), 400
+
+    raw_ids = payload.get("pks")
+    if not isinstance(raw_ids, list):
+        return jsonify({"ok": False, "error": "pks must be a list."}), 400
+
+    insert_sql = text(
+        """
+        INSERT INTO invoice_items (item_id, invoice_id)
+        VALUES (:item_id, :invoice_id)
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+    linked: List[str] = []
+    with get_engine().begin() as conn:
+        for candidate in raw_ids:
+            try:
+                normalized_invoice = normalize_pg_uuid(str(candidate))
+            except Exception as exc:
+                log.debug(
+                    "bulk_link_invoices_api: skipping invalid invoice identifier %r: %s",
+                    candidate,
+                    exc,
+                )
+                continue
+
+            result = conn.execute(
+                insert_sql,
+                {"item_id": normalized_target, "invoice_id": normalized_invoice},
+            )
+            if result.rowcount and result.rowcount > 0:
+                linked.append(normalized_invoice)
+
+    return jsonify({"ok": True, "linked": len(linked), "invoices": linked})
+
+
+@bp.route("/invoicesassociations", methods=["DELETE"])
+@login_required
+def bulk_unlink_invoices_api() -> Any:
+    payload = request.get_json(silent=True) or {}
+    table_name = str(payload.get("table") or "invoices").strip().lower()
+    if table_name != "invoices":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "Only invoice associations are supported by this endpoint.",
+                }
+            ),
+            400,
+        )
+
+    target_uuid = payload.get("target_uuid")
+    if not target_uuid:
+        return jsonify({"ok": False, "error": "Missing target UUID."}), 400
+
+    try:
+        normalized_target = normalize_pg_uuid(str(target_uuid))
+    except Exception as exc:
+        log.debug("bulk_unlink_invoices_api: invalid target UUID %r: %s", target_uuid, exc)
+        return jsonify({"ok": False, "error": "Invalid target UUID."}), 400
+
+    raw_ids = payload.get("pks")
+    if not isinstance(raw_ids, list):
+        return jsonify({"ok": False, "error": "pks must be a list."}), 400
+
+    normalized_invoices: List[str] = []
+    for candidate in raw_ids:
+        try:
+            normalized_invoices.append(normalize_pg_uuid(str(candidate)))
+        except Exception as exc:
+            log.debug(
+                "bulk_unlink_invoices_api: skipping invalid invoice identifier %r: %s",
+                candidate,
+                exc,
+            )
+
+    if not normalized_invoices:
+        return jsonify({"ok": False, "error": "No valid invoice identifiers supplied."}), 400
+
+    delete_sql = text(
+        """
+        DELETE FROM invoice_items
+        WHERE item_id = :item_id
+          AND invoice_id IN :invoice_ids
+        """
+    ).bindparams(bindparam("invoice_ids", expanding=True))
+
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            delete_sql,
+            {"item_id": normalized_target, "invoice_ids": normalized_invoices},
+        )
+
+    return jsonify(
+        {
+            "ok": True,
+            "removed": int(result.rowcount or 0),
+            "invoices": normalized_invoices,
+        }
+    )
+
+
+@bp.route("/invoicesbulkdelete", methods=["POST"])
+@login_required
+def bulk_delete_invoices_api() -> Any:
+    payload = request.get_json(silent=True) or {}
+    table_name = str(payload.get("table") or "invoices").strip().lower()
+    if table_name != "invoices":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "Only invoices can be deleted through this endpoint.",
+                }
+            ),
+            400,
+        )
+
+    raw_ids = payload.get("pks")
+    if not isinstance(raw_ids, list):
+        return jsonify({"ok": False, "error": "pks must be a list."}), 400
+
+    normalized_invoices: List[str] = []
+    for candidate in raw_ids:
+        try:
+            normalized_invoices.append(normalize_pg_uuid(str(candidate)))
+        except Exception as exc:
+            log.debug(
+                "bulk_delete_invoices_api: skipping invalid invoice identifier %r: %s",
+                candidate,
+                exc,
+            )
+
+    if not normalized_invoices:
+        return jsonify({"ok": False, "error": "No valid invoice identifiers supplied."}), 400
+
+    delete_sql = text(
+        """
+        UPDATE invoices
+        SET is_deleted = TRUE
+        WHERE id IN :invoice_ids
+        """
+    ).bindparams(bindparam("invoice_ids", expanding=True))
+
+    with get_engine().begin() as conn:
+        result = conn.execute(delete_sql, {"invoice_ids": normalized_invoices})
+
+    return jsonify(
+        {
+            "ok": True,
+            "deleted": int(result.rowcount or 0),
+            "invoices": normalized_invoices,
+        }
+    )

--- a/backend/app/items.py
+++ b/backend/app/items.py
@@ -18,7 +18,11 @@ from .embeddings import update_embeddings_for_item
 from .slugify import slugify
 from .helpers import normalize_pg_uuid, parse_tagged_text_to_dict
 from .static_server import get_public_html_path
-from .assoc_helper import CONTAINMENT_BIT  # Shared containment association flag defined centrally.
+from .assoc_helper import (
+    CONTAINMENT_BIT,
+    get_item_relationship,
+    set_item_relationship,
+)
 from .image_handler import (
     store_image_for_item,
     BadRequest as ImageBadRequest,
@@ -110,182 +114,6 @@ def _ensure_containment_relationship(conn: Any, source_id: str, target_id: str) 
             "assoc_type": CONTAINMENT_BIT,
         },
     )
-
-
-def get_item_relationship(first_identifier: Any, second_identifier: Any) -> Optional[Dict[str, Any]]:
-    """Retrieve or consolidate a relationship record between two items."""
-
-    # Normalize the incoming identifiers early so we can safely query the database.
-    try:
-        normalized_first = normalize_pg_uuid(str(first_identifier))
-        normalized_second = normalize_pg_uuid(str(second_identifier))
-    except Exception as exc:  # Broad on purpose: normalization is strict and raises TypeError/ValueError.
-        log.debug(
-            "Unable to normalize relationship identifiers %r and %r: %s",
-            first_identifier,
-            second_identifier,
-            exc,
-        )
-        return None
-
-    engine = get_engine()
-    with engine.begin() as conn:
-        selection = conn.execute(
-            text(
-                """
-                SELECT id, item_id, assoc_id, assoc_type
-                FROM relationships
-                WHERE (item_id = :first_id AND assoc_id = :second_id)
-                   OR (item_id = :second_id AND assoc_id = :first_id)
-                ORDER BY id
-                """
-            ),
-            {"first_id": normalized_first, "second_id": normalized_second},
-        ).mappings().all()
-
-        if not selection:
-            return None
-
-        if len(selection) == 1:
-            # Single hit means we can simply return the mapping as a regular dictionary.
-            return dict(selection[0])
-
-        # Multiple rows indicate duplicated relationship data. Consolidate them into one row.
-        combined_bits = 0
-        for row in selection:
-            try:
-                combined_bits |= int(row.get("assoc_type") or 0)
-            except (TypeError, ValueError):
-                # assoc_type is expected to behave like an integer. If it does not, treat as zero.
-                combined_bits |= 0
-
-        desired_item_id = normalized_first
-        desired_assoc_id = normalized_second
-        target_row = None
-        for row in selection:
-            if str(row.get("item_id")) == desired_item_id and str(row.get("assoc_id")) == desired_assoc_id:
-                target_row = dict(row)
-                break
-
-        if target_row is None:
-            # Reorient the first row we saw so the caller's specified order becomes canonical.
-            first_row = dict(selection[0])
-            conn.execute(
-                text(
-                    """
-                    UPDATE relationships
-                    SET item_id = :item_id, assoc_id = :assoc_id
-                    WHERE id = :relationship_id
-                    """
-                ),
-                {
-                    "item_id": desired_item_id,
-                    "assoc_id": desired_assoc_id,
-                    "relationship_id": first_row.get("id"),
-                },
-            )
-            target_row = first_row
-
-        # Ensure the canonical row contains the combined relationship flags.
-        conn.execute(
-            text(
-                """
-                UPDATE relationships
-                SET assoc_type = :assoc_type
-                WHERE id = :relationship_id
-                """
-            ),
-            {
-                "assoc_type": combined_bits,
-                "relationship_id": target_row.get("id"),
-            },
-        )
-
-        # Remove every other duplicate so a single authoritative record remains.
-        for row in selection:
-            if row.get("id") == target_row.get("id"):
-                continue
-            conn.execute(
-                text(
-                    """
-                    DELETE FROM relationships
-                    WHERE id = :relationship_id
-                    """
-                ),
-                {"relationship_id": row.get("id")},
-            )
-
-        final_row = conn.execute(
-            text(
-                """
-                SELECT id, item_id, assoc_id, assoc_type
-                FROM relationships
-                WHERE id = :relationship_id
-                """
-            ),
-            {"relationship_id": target_row.get("id")},
-        ).mappings().first()
-
-        return dict(final_row) if final_row else None
-
-
-def set_item_relationship(first_identifier: Any, second_identifier: Any, assoc_type: int) -> Optional[Dict[str, Any]]:
-    """Create or update a relationship while respecting existing directionality."""
-
-    existing = get_item_relationship(first_identifier, second_identifier)
-    if existing is None:
-        # Nothing persisted yet, so create a brand-new row using the caller's order.
-        try:
-            normalized_first = normalize_pg_uuid(str(first_identifier))
-            normalized_second = normalize_pg_uuid(str(second_identifier))
-        except Exception as exc:
-            log.debug(
-                "Unable to normalize relationship identifiers %r and %r for insert: %s",
-                first_identifier,
-                second_identifier,
-                exc,
-            )
-            return None
-
-        engine = get_engine()
-        with engine.begin() as conn:
-            conn.execute(
-                text(
-                    """
-                    INSERT INTO relationships (item_id, assoc_id, assoc_type)
-                    VALUES (:item_id, :assoc_id, :assoc_type)
-                    """
-                ),
-                {
-                    "item_id": normalized_first,
-                    "assoc_id": normalized_second,
-                    "assoc_type": int(assoc_type),
-                },
-            )
-
-        return get_item_relationship(first_identifier, second_identifier)
-
-    # An existing row already captures the relationship. Update the stored association bits
-    # without disturbing the persisted direction, regardless of the caller's ordering.
-    engine = get_engine()
-    with engine.begin() as conn:
-        conn.execute(
-            text(
-                """
-                UPDATE relationships
-                SET assoc_type = :assoc_type
-                WHERE id = :relationship_id
-                """
-            ),
-            {
-                "assoc_type": int(assoc_type),
-                "relationship_id": existing.get("id"),
-            },
-        )
-
-    # Refresh from the database to return the most current representation.
-    return get_item_relationship(existing.get("item_id"), existing.get("assoc_id"))
-
 def _synchronize_pinned_relationships(
     engine: Engine,
     *,
@@ -1069,3 +897,212 @@ def autogen_items_api():
         return jsonify({"success": False, "error": str(exc)}), 503
 
     return jsonify({"job_id": job_id})
+
+
+def delete_item_relationship(relationship_identifier: Any) -> Optional[Dict[str, Any]]:
+    """Remove a relationship row identified by its primary key."""
+
+    try:
+        normalized_relationship_id = normalize_pg_uuid(str(relationship_identifier))
+    except Exception as exc:
+        log.debug(
+            "Unable to normalize relationship identifier %r for deletion: %s",
+            relationship_identifier,
+            exc,
+        )
+        return None
+
+    engine = get_engine()
+    with engine.begin() as conn:
+        existing = conn.execute(
+            text(
+                """
+                SELECT id, item_id, assoc_id, assoc_type
+                FROM relationships
+                WHERE id = :relationship_id
+                """
+            ),
+            {"relationship_id": normalized_relationship_id},
+        ).mappings().first()
+
+        if existing is None:
+            return None
+
+        relationship_dict = dict(existing)
+
+        # TODO: Surface relationship_dict to an auditing or notification pipeline so the caller can react.
+
+        conn.execute(
+            text(
+                """
+                DELETE FROM relationships
+                WHERE id = :relationship_id
+                """
+            ),
+            {"relationship_id": normalized_relationship_id},
+        )
+
+        return relationship_dict
+
+
+@bp.route("/bulkassoc", methods=["POST"])
+@login_required
+def bulk_associate_items_api():
+    payload = request.get_json(silent=True) or {}
+    table_name = str(payload.get("table") or "items").strip().lower()
+    if table_name != "items":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "Only item associations are supported by this endpoint.",
+                }
+            ),
+            400,
+        )
+
+    target_uuid = payload.get("target_uuid")
+    if not target_uuid:
+        return jsonify({"ok": False, "error": "Missing target UUID."}), 400
+
+    try:
+        normalized_target = normalize_pg_uuid(str(target_uuid))
+    except Exception as exc:
+        log.debug("bulk_associate_items_api: invalid target UUID %r: %s", target_uuid, exc)
+        return jsonify({"ok": False, "error": "Invalid target UUID."}), 400
+
+    raw_ids = payload.get("pks")
+    if not isinstance(raw_ids, list):
+        return jsonify({"ok": False, "error": "pks must be a list."}), 400
+
+    try:
+        assoc_bits = int(payload.get("association_type", 0))
+    except (TypeError, ValueError):
+        assoc_bits = 0
+
+    processed: List[str] = []
+    for candidate in raw_ids:
+        try:
+            normalized_candidate = normalize_pg_uuid(str(candidate))
+        except Exception as exc:
+            log.debug(
+                "bulk_associate_items_api: skipping invalid item identifier %r: %s",
+                candidate,
+                exc,
+            )
+            continue
+
+        result = set_item_relationship(normalized_candidate, normalized_target, assoc_bits)
+        if result is None:
+            continue
+        processed.append(str(result.get("id") or normalized_candidate))
+
+    return jsonify({"ok": True, "updated": len(processed), "relationships": processed})
+
+
+@bp.route("/bulkassoc", methods=["DELETE"])
+@login_required
+def bulk_remove_item_associations_api():
+    payload = request.get_json(silent=True) or {}
+    table_name = str(payload.get("table") or "items").strip().lower()
+    if table_name != "items":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "Only item associations are supported by this endpoint.",
+                }
+            ),
+            400,
+        )
+
+    target_uuid = payload.get("target_uuid")
+    if not target_uuid:
+        return jsonify({"ok": False, "error": "Missing target UUID."}), 400
+
+    try:
+        normalized_target = normalize_pg_uuid(str(target_uuid))
+    except Exception as exc:
+        log.debug("bulk_remove_item_associations_api: invalid target UUID %r: %s", target_uuid, exc)
+        return jsonify({"ok": False, "error": "Invalid target UUID."}), 400
+
+    raw_ids = payload.get("pks")
+    if not isinstance(raw_ids, list):
+        return jsonify({"ok": False, "error": "pks must be a list."}), 400
+
+    removed: List[str] = []
+    for candidate in raw_ids:
+        try:
+            normalized_candidate = normalize_pg_uuid(str(candidate))
+        except Exception as exc:
+            log.debug(
+                "bulk_remove_item_associations_api: skipping invalid item identifier %r: %s",
+                candidate,
+                exc,
+            )
+            continue
+
+        relationship = get_item_relationship(normalized_candidate, normalized_target)
+        if not relationship:
+            continue
+
+        deleted = delete_item_relationship(relationship.get("id"))
+        if deleted is None:
+            continue
+        removed.append(str(relationship.get("id")))
+
+    return jsonify({"ok": True, "removed": len(removed), "relationships": removed})
+
+
+@bp.route("/bulkdelete", methods=["POST"])
+@login_required
+def bulk_delete_items_api():
+    payload = request.get_json(silent=True) or {}
+    table_name = str(payload.get("table") or "items").strip().lower()
+    if table_name != "items":
+        return (
+            jsonify(
+                {
+                    "ok": False,
+                    "error": "Only inventory items can be deleted through this endpoint.",
+                }
+            ),
+            400,
+        )
+
+    raw_ids = payload.get("pks")
+    if not isinstance(raw_ids, list):
+        return jsonify({"ok": False, "error": "pks must be a list."}), 400
+
+    normalized_ids: List[str] = []
+    for candidate in raw_ids:
+        try:
+            normalized_ids.append(normalize_pg_uuid(str(candidate)))
+        except Exception as exc:
+            log.debug(
+                "bulk_delete_items_api: skipping invalid item identifier %r: %s",
+                candidate,
+                exc,
+            )
+
+    if not normalized_ids:
+        return jsonify({"ok": False, "error": "No valid item identifiers supplied."}), 400
+
+    delete_sql = text(
+        """
+        UPDATE items
+        SET is_deleted = TRUE
+        WHERE id IN :item_ids
+        """
+    ).bindparams(bindparam("item_ids", expanding=True))
+
+    with get_engine().begin() as conn:
+        result = conn.execute(delete_sql, {"item_ids": normalized_ids})
+
+    return jsonify(
+        {
+            "ok": True,
+            "deleted": int(result.rowcount or 0),
+            "processed_ids": normalized_ids,
+        }
+    )

--- a/frontend/src/app/components/SearchPanel.tsx
+++ b/frontend/src/app/components/SearchPanel.tsx
@@ -213,9 +213,6 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
   const [isActionBusy, setIsActionBusy] = useState<boolean>(false);
   const [hasQueried, setHasQueried] = useState<boolean>(false);
   const [selectedPks, setSelectedPks] = useState<Set<string>>(new Set());
-  const [relationDirection, setRelationDirection] = useState<
-    "forward" | "reverse"
-  >("forward");
   const [associationBits, setAssociationBits] = useState<number>(
     CONTAINMENT_BIT,
   );
@@ -816,13 +813,12 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
       const response = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          table: normalizedTable,
-          target_uuid: targetUuid,
-          pks: ids,
-          association_type: associationBits,
-          direction: relationDirection,
-        }),
+          body: JSON.stringify({
+            table: normalizedTable,
+            target_uuid: targetUuid,
+            pks: ids,
+            association_type: associationBits,
+          }),
       });
       let payload: any = null;
       try {
@@ -868,7 +864,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     } finally {
       setIsActionBusy(false);
     }
-  }, [associationBits, associationSummary, isInvoiceMode, normalizedTable, query, relationDirection, runSearch, selectedCount, selectedPks, targetUuid]);
+  }, [associationBits, associationSummary, isInvoiceMode, normalizedTable, query, runSearch, selectedCount, selectedPks, targetUuid]);
 
   const handleUnlinkAssociation = useCallback(async () => {
     if (!targetUuid || selectedCount === 0) {
@@ -881,12 +877,11 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
       const response = await fetch(endpoint, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          table: normalizedTable,
-          target_uuid: targetUuid,
-          pks: ids,
-          direction: relationDirection,
-        }),
+          body: JSON.stringify({
+            table: normalizedTable,
+            target_uuid: targetUuid,
+            pks: ids,
+          }),
       });
       let payload: any = null;
       try {
@@ -925,7 +920,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     } finally {
       setIsActionBusy(false);
     }
-  }, [normalizedTable, query, relationDirection, runSearch, selectedCount, selectedPks, targetUuid]);
+  }, [normalizedTable, query, runSearch, selectedCount, selectedPks, targetUuid]);
 
   const resolveThumbnail = useCallback((row: SearchRow): string => {
     if (smallMode || normalizedTable !== "items") {
@@ -1170,25 +1165,6 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
                   </>
                 ) : (
                   <>
-                    <button
-                      type="button"
-                      className="btn btn-outline-secondary btn-sm"
-                      onClick={() =>
-                        setRelationDirection((prev) =>
-                          prev === "forward" ? "reverse" : "forward"
-                        )
-                      }
-                      disabled={isBusy}
-                      aria-pressed={relationDirection === "reverse"}
-                      title={
-                        relationDirection === "forward"
-                          ? "Link from selected entries to target"
-                          : "Link from target to selected entries"
-                      }
-                    >
-                      {relationDirection === "forward" ? "➡️" : "⬅️"}
-                    </button>
-
                     <div className="d-flex align-items-center gap-2">
                       {ALL_ASSOCIATION_BITS.map((bit) => {
                         const checked =


### PR DESCRIPTION
## Summary
- move relationship helper functions into assoc_helper for reuse
- add item and invoice bulk association and delete endpoints on the backend
- simplify the search panel footer by removing the relationship direction toggle and using the new APIs

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68db1fcf5540832ba9d3de8d44ab347e