### PR TITLE
Disable email check on home invoice upload and redirect to ledger

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -58,6 +58,20 @@ const HomePage: React.FC = () => {
     [navigate],
   );
 
+  const handleInvoiceSearchSuggestion = useCallback(
+    (query: string) => {
+      // Ensure the invoice search page opens with a meaningful query whenever uploads finish.
+      const sanitized = query.trim();
+      if (!sanitized) {
+        navigate("/ledger");
+        return;
+      }
+      const encoded = encodeURIComponent(sanitized);
+      navigate(`/ledger/${encoded}`);
+    },
+    [navigate],
+  );
+
   if (status === "loading") {
     return <p>Loading…</p>;
   }
@@ -87,7 +101,10 @@ const HomePage: React.FC = () => {
           refreshToken={searchRefreshToken}
         />
       </div>
-      <InvoiceUploaderPanel />
+      <InvoiceUploaderPanel
+        onSearchPrefillSuggested={handleInvoiceSearchSuggestion}
+        showCheckEmailPanel={false}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide the manual email check controls when the home page renders the invoice uploader
- redirect home page uploads to the ledger search with the recommended query prefilled so users land on fresh results

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68db53d258ac832bb24b0523da37df2d