### PR TITLE
Add processed invoice check to shop handlers

### DIFF
--- a/backend/shop_handler/amazon_handler.py
+++ b/backend/shop_handler/amazon_handler.py
@@ -15,6 +15,10 @@ log = logging.getLogger(__name__)
 class AmazonHandler(ShopHandler):
     """Handler for Amazon order invoices."""
 
+    def has_already_been_handled(self, shop_name: str, order_number: str) -> bool:
+        """Amazon invoices reuse the shared human-processing lookup without modification."""
+        return super().has_already_been_handled(shop_name, order_number)
+
     POSSIBLE_NAMES = (
         "Amazon",
     )

--- a/backend/shop_handler/digikey_handler.py
+++ b/backend/shop_handler/digikey_handler.py
@@ -16,6 +16,10 @@ log = logging.getLogger(__name__)
 class DigiKeyHandler(ShopHandler):
     """Handler for Digi-Key order invoices."""
 
+    def has_already_been_handled(self, shop_name: str, order_number: str) -> bool:
+        """Digi-Key invoices reuse the shared human-processing lookup without modification."""
+        return super().has_already_been_handled(shop_name, order_number)
+
     POSSIBLE_NAMES = (
         "Digi-Key",
         "Digi Key",

--- a/backend/shop_handler/mcmastercarr_handler.py
+++ b/backend/shop_handler/mcmastercarr_handler.py
@@ -13,6 +13,10 @@ from automation.web_get import fetch_with_playwright
 class McMasterCarrHandler(ShopHandler):
     """Handler for McMaster-Carr order invoices."""
 
+    def has_already_been_handled(self, shop_name: str, order_number: str) -> bool:
+        """McMaster-Carr invoices reuse the shared human-processing lookup without modification."""
+        return super().has_already_been_handled(shop_name, order_number)
+
     POSSIBLE_NAMES = (
         "McMaster-Carr",
         "McMaster",


### PR DESCRIPTION
## Summary
- add a shared `has_already_been_handled` database lookup on `ShopHandler` so callers can skip invoices already marked as processed by a human
- expose convenience overrides on each concrete shop handler so they reuse the shared lookup and document the intent

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dc1ace4328832ba1621ee915c6e811