### PR TITLE
Prune unused environment variables from backend template

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,85 +3,22 @@
 # =========================
 # Copy this file to backend/.env and edit values as needed.
 # Do NOT commit backend/.env.
+# The variables below are the only ones the current backend code reads.
 
-# --- App / Server ---
-APP_NAME=your-app
-FLASK_APP=app/main.py
-FLASK_ENV=development            # 'production' in prod
-FLASK_DEBUG=1                    # 0 in prod
-API_PREFIX=/api
-SERVER_HOST=127.0.0.1
-SERVER_PORT=5000
+# --- Flask runtime behaviour ---
+FLASK_ENV=development            # Use 'production' for deployed environments.
+LOG_LEVEL=INFO                   # Accepted values: DEBUG, INFO, WARNING, ERROR.
 
-# --- Security ---
-# Change these in production!
-SECRET_KEY=change-me-in-prod     # used for sessions/signing
-JWT_SECRET=dev-jwt-secret        # if you use JWTs
-JWT_EXPIRES_IN=3600              # seconds (e.g., 1 hour)
-
-# Cookie hardening (if you use Flask sessions/cookies)
-SESSION_COOKIE_SECURE=0          # 1 in prod (HTTPS only)
-SESSION_COOKIE_SAMESITE=Lax      # Lax | Strict | None
-SESSION_COOKIE_HTTPONLY=1
-
-# --- Logging ---
-LOG_LEVEL=INFO                   # DEBUG, INFO, WARNING, ERROR
-
-# --- CORS (frontend dev on Vite 5173) ---
-# Comma-separated list of origins allowed to hit the API
-CORS_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
-
-# --- Database (Postgres) ---
-# Provide both a full URL (what the app actually uses) and the parts
-# (handy for docker compose / tooling). Note: most dotenv loaders DO NOT
-# expand variables inside other variables, so keep DATABASE_URL explicit.
+# --- Database connection ---
+DATABASE_URL=postgresql+psycopg://app:app@127.0.0.1:5432/app
 DB_USER=app
 DB_PASSWORD=app
 DB_NAME=app
 DB_HOST=127.0.0.1
 DB_PORT=5432
-DATABASE_URL=postgresql+psycopg://app:app@127.0.0.1:5432/app
 
-# SQLAlchemy tuning (optional)
-SQLALCHEMY_ECHO=0                # 1 to log SQL
+# --- SQLAlchemy tuning knobs ---
+SQLALCHEMY_ECHO=0                # Set to 1 to log SQL statements for debugging.
 SQLALCHEMY_POOL_SIZE=5
 SQLALCHEMY_MAX_OVERFLOW=10
 SQLALCHEMY_POOL_PRE_PING=1
-
-# --- Alembic (optional but recommended) ---
-# If your alembic/env.py reads from env, point to the DB here.
-ALEMBIC_DATABASE_URL=${DATABASE_URL}
-# If you keep migrations under repo_root/infra/migrations:
-ALEMBIC_SCRIPT_LOCATION=../infra/migrations
-
-# --- File uploads (optional) ---
-# Relative to repo root or absolute path
-UPLOAD_DIR=../var/uploads
-MAX_CONTENT_LENGTH=16777216      # bytes (16 MB)
-
-# --- Email (optional) ---
-MAIL_SERVER=localhost
-MAIL_PORT=1025
-MAIL_USE_TLS=0
-MAIL_USE_SSL=0
-MAIL_USERNAME=
-MAIL_PASSWORD=
-MAIL_DEFAULT_SENDER="Your App <no-reply@example.com>"
-
-# --- Storage backend (optional) ---
-# STORAGE_BACKEND=local | s3
-STORAGE_BACKEND=local
-S3_BUCKET=
-S3_REGION=
-S3_ENDPOINT=
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-
-# --- Observability (optional) ---
-SENTRY_DSN=
-SENTRY_TRACES_SAMPLE_RATE=0.0    # 0.0–1.0
-
-# --- Feature flags / misc (optional) ---
-FEATURE_EXPERIMENTAL_UI=0
-PAGINATION_DEFAULT_LIMIT=50
-RATE_LIMIT_PER_MINUTE=120


### PR DESCRIPTION
## Summary
- trim backend/.env.example to only document the environment variables that the code actually reads
- refresh inline comments so the remaining entries explain how to use them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc9cd3a250832bb53cc5e5ded8b3d2