### PR TITLE
Add history log viewer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from .image_handler import bp_image
 from .user_login import bp as bp_auth
 from .invoice_handlers import bp as bp_invoice, check_email_task
 from .items import bp as bp_items
+from .history import bp as bp_history
 from .maint import bp as bp_maint
 from .search import bp as bp_search
 from .job_manager import JobManager, RepeatableJob, bp as bp_jobs
@@ -62,6 +63,7 @@ def create_app():
     app.register_blueprint(bp_search)
     app.register_blueprint(bp_invoice)
     app.register_blueprint(bp_items)
+    app.register_blueprint(bp_history)
     app.register_blueprint(bp_maint)
     app.register_blueprint(bp_jobs)
     app.register_blueprint(bp_dbstatus)

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -15,6 +15,7 @@ const HealthPage       = lazy(() => import("../pages/HealthPage"));
 const TestPage         = lazy(() => import("../pages/TestPage"));
 const NotFoundPage     = lazy(() => import("../pages/NotFoundPage"));
 const HelpPage         = lazy(() => import("../pages/HelpPage"));
+const HistoryLogView  = lazy(() => import("../pages/HistoryLogView"));
 
 const App: React.FC = () => {
   return (
@@ -49,6 +50,8 @@ const App: React.FC = () => {
           <Route path="/test/:xyz" element={<TestPage />} />
 
           {/* Utilities */}
+          <Route path="/history" element={<HistoryLogView />} />
+          <Route path="/history/:page" element={<HistoryLogView />} />
           <Route path="/help" element={<HelpPage />} />
 
           {/* 404 */}

--- a/frontend/src/app/Shell.tsx
+++ b/frontend/src/app/Shell.tsx
@@ -128,6 +128,7 @@ const Shell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           >
             Junk-Warehouse <img src="/imgs/icons/github_white_sq.png" height="18" width="18" />
           </a>
+          <Link to="/history" style={{ color: "inherit", textDecoration: "none" }}>🪵</Link>
           <a href="/help" target="_blank" style={{ color: "inherit", textDecoration: "none" }}>
             🙋ℹ️
           </a>

--- a/frontend/src/pages/HistoryLogView.tsx
+++ b/frontend/src/pages/HistoryLogView.tsx
@@ -1,0 +1,272 @@
+import React from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Modal from "react-bootstrap/Modal";
+import Spinner from "react-bootstrap/Spinner";
+import Table from "react-bootstrap/Table";
+
+interface HistoryEntry {
+    id: string | null;
+    date: string;
+    username: string;
+    itemId1: string | null;
+    itemId2: string | null;
+    event: string;
+    meta: string;
+    itemNamePreview: string | null;
+    itemNameFull: string | null;
+}
+
+interface HistoryResponse {
+    ok: boolean;
+    page: number;
+    pageSize: number;
+    hasNext: boolean;
+    hasPrevious: boolean;
+    entries: HistoryEntry[];
+    error?: string;
+}
+
+const PAGE_SIZE = 100;
+
+const HistoryLogView: React.FC = () => {
+    // Derive the desired page number from the route parameter; default to the first page when absent or invalid.
+    const params = useParams<{ page?: string }>();
+    const navigate = useNavigate();
+    const requestedPage = React.useMemo(() => {
+        const rawValue = params.page;
+        if (!rawValue) {
+            return 1;
+        }
+        const parsed = Number(rawValue);
+        if (!Number.isInteger(parsed) || parsed < 1) {
+            return 1;
+        }
+        return parsed;
+    }, [params.page]);
+
+    const [entries, setEntries] = React.useState<HistoryEntry[]>([]);
+    const [loading, setLoading] = React.useState<boolean>(false);
+    const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+    const [hasNext, setHasNext] = React.useState<boolean>(false);
+    const [hasPrevious, setHasPrevious] = React.useState<boolean>(false);
+    const [selectedEntry, setSelectedEntry] = React.useState<HistoryEntry | null>(null);
+
+    React.useEffect(() => {
+        let isActive = true;
+        const controller = new AbortController();
+
+        const loadHistory = async () => {
+            setLoading(true);
+            setErrorMessage(null);
+            try {
+                const targetPath = requestedPage <= 1 ? "/api/history" : `/api/history/${requestedPage}`;
+                const response = await fetch(targetPath, {
+                    method: "GET",
+                    credentials: "include",
+                    signal: controller.signal,
+                });
+                if (!isActive) {
+                    return;
+                }
+                if (response.status !== 200) {
+                    const text = await response.text();
+                    throw new Error(text || "Unable to retrieve history entries.");
+                }
+                const payload = (await response.json()) as HistoryResponse;
+                if (!payload.ok) {
+                    throw new Error(payload.error || "The server reported an unknown error.");
+                }
+                setEntries(payload.entries ?? []);
+                setHasNext(Boolean(payload.hasNext));
+                setHasPrevious(Boolean(payload.hasPrevious));
+            } catch (error) {
+                if (!isActive) {
+                    return;
+                }
+                const friendlyMessage = error instanceof Error ? error.message : "Unable to retrieve history entries.";
+                setErrorMessage(friendlyMessage);
+                setEntries([]);
+                setHasNext(false);
+                setHasPrevious(requestedPage > 1);
+            } finally {
+                if (isActive) {
+                    setLoading(false);
+                }
+            }
+        };
+
+        loadHistory();
+
+        return () => {
+            isActive = false;
+            controller.abort();
+        };
+    }, [requestedPage]);
+
+    // Navigate to the desired page while keeping the first page route concise.
+    const navigateToPage = (pageNumber: number) => {
+        const safePage = pageNumber < 1 ? 1 : pageNumber;
+        if (safePage === 1) {
+            navigate("/history", { replace: false });
+        } else {
+            navigate(`/history/${safePage}`, { replace: false });
+        }
+    };
+
+    const formatDate = (value: string) => {
+        try {
+            const date = new Date(value);
+            if (!Number.isNaN(date.getTime())) {
+                return date.toLocaleString();
+            }
+        } catch {
+            // Ignore conversion failures and fall back to the original text.
+        }
+        return value;
+    };
+
+    const renderLinkedUuid = (label: string, uuidValue: string | null) => {
+        if (!uuidValue) {
+            return (
+                <div>
+                    <strong>{label}:</strong> <span>—</span>
+                </div>
+            );
+        }
+        return (
+            <div>
+                <strong>{label}:</strong> <Link to={`/item/${uuidValue}`}>{uuidValue}</Link>
+            </div>
+        );
+    };
+
+    return (
+        <div className="py-3">
+            <h1 className="h3 mb-3">History Log</h1>
+            <p className="text-muted">
+                Review the most recent {PAGE_SIZE} recorded events. Click any row to examine the full entry, including
+                metadata.
+            </p>
+            {errorMessage && (
+                <Alert variant="danger" className="mt-3">
+                    {errorMessage}
+                </Alert>
+            )}
+            <div className="table-responsive">
+                <Table striped bordered hover responsive>
+                    <thead>
+                        <tr>
+                            <th style={{ width: "20%" }}>Date and Time</th>
+                            <th style={{ width: "50%" }}>Event</th>
+                            <th style={{ width: "30%" }}>Linked Item Preview</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {loading && (
+                            <tr>
+                                <td colSpan={3} className="text-center">
+                                    <Spinner animation="border" role="status" size="sm" className="me-2" /> Loading
+                                    history…
+                                </td>
+                            </tr>
+                        )}
+                        {!loading && entries.length === 0 && (
+                            <tr>
+                                <td colSpan={3} className="text-center text-muted">
+                                    No history entries are available.
+                                </td>
+                            </tr>
+                        )}
+                        {!loading &&
+                            entries.map((entry) => (
+                                <tr
+                                    key={entry.id ?? `${entry.date}-${entry.event}`}
+                                    role="button"
+                                    onClick={() => setSelectedEntry(entry)}
+                                >
+                                    <td>{formatDate(entry.date)}</td>
+                                    <td>{entry.event || "(no description provided)"}</td>
+                                    <td>{entry.itemNamePreview ?? "—"}</td>
+                                </tr>
+                            ))}
+                    </tbody>
+                </Table>
+            </div>
+
+            <div className="d-flex justify-content-center align-items-center gap-3 mt-3">
+                <Button
+                    variant="outline-secondary"
+                    disabled={loading || !hasPrevious}
+                    onClick={() => navigateToPage(requestedPage - 1)}
+                >
+                    ⬅️
+                </Button>
+                <span className="fw-semibold">Page {requestedPage}</span>
+                <Button
+                    variant="outline-secondary"
+                    disabled={loading || !hasNext}
+                    onClick={() => navigateToPage(requestedPage + 1)}
+                >
+                    ➡️
+                </Button>
+            </div>
+
+            <Modal show={selectedEntry !== null} onHide={() => setSelectedEntry(null)} size="lg" centered>
+                <Modal.Header closeButton>
+                    <Modal.Title>History Entry Details</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {selectedEntry && (
+                        <div className="d-flex flex-column gap-2">
+                            <div>
+                                <strong>Entry ID:</strong> <span>{selectedEntry.id ?? "—"}</span>
+                            </div>
+                            <div>
+                                <strong>Date:</strong> <span>{formatDate(selectedEntry.date)}</span>
+                            </div>
+                            <div>
+                                <strong>Username:</strong> <span>{selectedEntry.username || "—"}</span>
+                            </div>
+                            {renderLinkedUuid("Item ID 1", selectedEntry.itemId1)}
+                            {renderLinkedUuid("Item ID 2", selectedEntry.itemId2)}
+                            <div>
+                                <strong>Item Name:</strong> <span>{selectedEntry.itemNameFull ?? "—"}</span>
+                            </div>
+                            <div>
+                                <strong>Event:</strong> <span>{selectedEntry.event || "—"}</span>
+                            </div>
+                            <div>
+                                <strong>Meta:</strong>
+                                <pre
+                                    style={{
+                                        maxHeight: "24rem",
+                                        minHeight: "12rem",
+                                        overflowY: "auto",
+                                        backgroundColor: "#f8f9fa",
+                                        border: "1px solid #dee2e6",
+                                        borderRadius: "0.5rem",
+                                        padding: "1rem",
+                                        marginTop: "0.5rem",
+                                    }}
+                                >
+                                    <code style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                                        {selectedEntry.meta || "(no metadata provided)"}
+                                    </code>
+                                </pre>
+                            </div>
+                        </div>
+                    )}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={() => setSelectedEntry(null)}>
+                        Close
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        </div>
+    );
+};
+
+export default HistoryLogView;


### PR DESCRIPTION
## Summary
- add a paginated history API that joins item names so the UI can show concise previews
- register the history blueprint and surface a History Log route in the React app shell
- implement the HistoryLogView page with table pagination, detail modal, and footer link

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dc9ff35cd0832babf48ff130743605