### PR TITLE
Add containment path viewer for items

### DIFF
--- a/backend/app/contaiment_path.py
+++ b/backend/app/contaiment_path.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Iterable, List, Mapping, Sequence
+
+from sqlalchemy import text
+
+from .assoc_helper import CONTAINMENT_BIT
+from .db import get_engine
+from .helpers import normalize_pg_uuid
+
+log = logging.getLogger(__name__)
+
+
+def _normalize_identifier(value: Any) -> str:
+    """Normalize arbitrary identifier inputs into a canonical UUID string.
+
+    This helper accepts UUID instances, dictionaries containing an ``id`` key,
+    and any other object that can be coerced into text for normalization.  A
+    ``ValueError`` is raised when the value cannot be interpreted as a UUID so
+    callers can provide a helpful error message upstream.
+    """
+
+    if isinstance(value, uuid.UUID):
+        return str(value)
+
+    if isinstance(value, Mapping):
+        if "id" in value:
+            return _normalize_identifier(value["id"])
+        if "uuid" in value:
+            return _normalize_identifier(value["uuid"])
+
+    if value is None:
+        raise ValueError("Identifier is required to resolve containment data.")
+
+    return normalize_pg_uuid(str(value))
+
+
+def get_all_containments(item_identifier: Any) -> List[str]:
+    """Return UUIDs connected to the target item by containment relationships.
+
+    The query inspects both directions of the relationship so the caller does
+    not need to know whether the item was stored as ``item_id`` or ``assoc_id``.
+    Duplicate entries are filtered out to keep the result clean for consumers.
+    """
+
+    normalized = _normalize_identifier(item_identifier)
+
+    engine = get_engine()
+    with engine.begin() as conn:
+        rows: Sequence[str] = conn.execute(
+            text(
+                """
+                SELECT DISTINCT
+                    CASE
+                        WHEN item_id = :target THEN assoc_id
+                        ELSE item_id
+                    END AS related_id
+                FROM relationships
+                WHERE (item_id = :target OR assoc_id = :target)
+                  AND (COALESCE(assoc_type, 0) & :containment_bit) <> 0
+                  AND CASE
+                        WHEN item_id = :target THEN assoc_id
+                        ELSE item_id
+                      END IS NOT NULL
+                ORDER BY related_id
+                """
+            ),
+            {"target": normalized, "containment_bit": CONTAINMENT_BIT},
+        ).scalars().all()
+
+    return [str(uuid.UUID(str(row))) for row in rows]
+
+
+def fetch_containment_paths(item_identifier: Any) -> List[dict[str, Any]]:
+    """Return every containment path reachable from the provided item.
+
+    The implementation relies on a PostgreSQL recursive CTE so the database can
+    efficiently explore the containment graph.  Paths terminate when they reach
+    either an item marked as ``is_fixed_location`` or when no further
+    containment relationships are available (a dead end).  Each entry contains
+    both the UUID path and a matching list of item names so the caller can
+    present user-friendly breadcrumbs.
+    """
+
+    normalized = _normalize_identifier(item_identifier)
+
+    engine = get_engine()
+    sql = text(
+        """
+        WITH RECURSIVE containment_tree AS (
+            SELECT
+                i.id AS current_id,
+                ARRAY[i.id] AS path,
+                ARRAY[i.name] AS name_path,
+                i.is_fixed_location
+            FROM items AS i
+            WHERE i.id = :target
+        UNION ALL
+            SELECT
+                neighbor.id AS current_id,
+                containment_tree.path || neighbor.id AS path,
+                containment_tree.name_path || neighbor.name AS name_path,
+                neighbor.is_fixed_location
+            FROM containment_tree
+            JOIN relationships AS r
+              ON (r.item_id = containment_tree.current_id OR r.assoc_id = containment_tree.current_id)
+             AND (COALESCE(r.assoc_type, 0) & :containment_bit) <> 0
+            JOIN items AS neighbor
+              ON neighbor.id = CASE
+                    WHEN r.item_id = containment_tree.current_id THEN r.assoc_id
+                    ELSE r.item_id
+                END
+            WHERE NOT neighbor.id = ANY(containment_tree.path)
+        ),
+        terminal_paths AS (
+            SELECT
+                containment_tree.path,
+                containment_tree.name_path,
+                containment_tree.current_id,
+                containment_tree.is_fixed_location,
+                NOT EXISTS (
+                    SELECT 1
+                    FROM relationships AS r2
+                    JOIN items AS neighbor2
+                      ON neighbor2.id = CASE
+                            WHEN r2.item_id = containment_tree.current_id THEN r2.assoc_id
+                            ELSE r2.item_id
+                        END
+                    WHERE (COALESCE(r2.assoc_type, 0) & :containment_bit) <> 0
+                      AND (r2.item_id = containment_tree.current_id OR r2.assoc_id = containment_tree.current_id)
+                      AND NOT neighbor2.id = ANY(containment_tree.path)
+                ) AS is_dead_end
+            FROM containment_tree
+        )
+        SELECT
+            path,
+            name_path,
+            is_fixed_location,
+            is_dead_end
+        FROM terminal_paths
+        WHERE is_fixed_location OR is_dead_end
+        ORDER BY cardinality(path) DESC, path
+        """
+    )
+
+    results: List[dict[str, Any]] = []
+    with engine.begin() as conn:
+        for row in conn.execute(sql, {"target": normalized, "containment_bit": CONTAINMENT_BIT}).mappings():
+            raw_path: Iterable[Any] = row.get("path") or []
+            raw_names: Iterable[Any] = row.get("name_path") or []
+            normalized_path = [str(uuid.UUID(str(value))) for value in raw_path]
+            name_list = [str(value) if value is not None else "" for value in raw_names]
+            results.append(
+                {
+                    "path": normalized_path,
+                    "names": name_list,
+                    "terminal_is_fixed_location": bool(row.get("is_fixed_location")),
+                    "terminal_is_dead_end": bool(row.get("is_dead_end")),
+                }
+            )
+
+    return results

--- a/frontend/src/app/components/ContainmentPathPanel.tsx
+++ b/frontend/src/app/components/ContainmentPathPanel.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import { API_BASE } from "../api";
+
+interface ContainmentPathEntry {
+  path: string[];
+  names: string[];
+  terminal_is_fixed_location: boolean;
+  terminal_is_dead_end: boolean;
+}
+
+interface ContainmentPathPanelProps {
+  targetUuid?: string | null;
+  refreshSignal?: number;
+}
+
+interface DisplayRow {
+  ids: string[];
+  names: string[];
+  summary: string;
+  terminalIsFixed: boolean;
+}
+
+const MAX_DISPLAY_NAME_LENGTH = 10;
+
+function coerceName(value: string | null | undefined): string {
+  const trimmed = (value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : "Unnamed item";
+}
+
+function formatDisplayName(name: string): string {
+  if (name.length <= MAX_DISPLAY_NAME_LENGTH) {
+    return name;
+  }
+  if (MAX_DISPLAY_NAME_LENGTH <= 1) {
+    return name.slice(0, MAX_DISPLAY_NAME_LENGTH);
+  }
+  // Keep the visible text compact while signalling truncation clearly.
+  return `${name.slice(0, MAX_DISPLAY_NAME_LENGTH - 1)}…`;
+}
+
+const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
+  targetUuid,
+  refreshSignal = 0,
+}) => {
+  const [paths, setPaths] = useState<ContainmentPathEntry[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!targetUuid) {
+      // When the item is not yet saved there is nothing to show.
+      setPaths([]);
+      setErrorMessage(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    let isActive = true;
+
+    const loadPaths = async () => {
+      setLoading(true);
+      setErrorMessage(null);
+      try {
+        const response = await fetch(
+          `${API_BASE}/api/containmentpaths?target_uuid=${encodeURIComponent(targetUuid)}`,
+          { signal: controller.signal, credentials: "include" }
+        );
+        let payload: any = null;
+        try {
+          payload = await response.json();
+        } catch {
+          payload = null;
+        }
+        if (!response.ok) {
+          const message =
+            payload && typeof payload === "object" && "error" in payload
+              ? String(payload.error)
+              : `Request failed (${response.status})`;
+          throw new Error(message);
+        }
+        if (payload && typeof payload === "object" && payload.ok === false) {
+          throw new Error(payload.error ? String(payload.error) : "Request failed");
+        }
+        const rawPaths: ContainmentPathEntry[] = Array.isArray(payload?.paths)
+          ? (payload.paths as ContainmentPathEntry[])
+          : [];
+        if (isActive) {
+          setPaths(rawPaths);
+        }
+      } catch (error: any) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        if (isActive) {
+          setPaths([]);
+          setErrorMessage(error?.message || "Unable to load containment paths.");
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadPaths();
+
+    return () => {
+      isActive = false;
+      controller.abort();
+    };
+  }, [targetUuid, refreshSignal]);
+
+  // Pre-compute display-friendly rows so the render logic remains easy to read.
+  const displayRows = useMemo<DisplayRow[]>(() => {
+    if (!paths.length) {
+      return [];
+    }
+    return paths.map((entry) => {
+      const ids = Array.isArray(entry.path) ? entry.path : [];
+      const names = Array.isArray(entry.names) ? entry.names : [];
+      const resolvedNames = ids.map((id, index) => coerceName(names[index]));
+      const isFixed = Boolean(entry.terminal_is_fixed_location);
+      const summary = isFixed
+        ? "🏠 Fixed location reached at the end of this path."
+        : "🔚 No further containment relationships beyond this point.";
+      return {
+        ids,
+        names: resolvedNames,
+        summary,
+        terminalIsFixed: isFixed,
+      };
+    });
+  }, [paths]);
+
+  return (
+    <div className="mb-4">
+      <div className="d-flex align-items-center justify-content-between mb-2">
+        <h2 className="h5 mb-0">Containment Paths</h2>
+      </div>
+      {!targetUuid && (
+        <div className="text-muted">Save the item to explore containment paths.</div>
+      )}
+      {targetUuid && loading && (
+        <div className="text-muted">Loading containment information…</div>
+      )}
+      {targetUuid && !loading && errorMessage && (
+        <div className="alert alert-warning py-2 px-3" role="status">
+          {errorMessage}
+        </div>
+      )}
+      {targetUuid && !loading && !errorMessage && displayRows.length === 0 && (
+        <div className="text-muted">No containment paths are currently recorded.</div>
+      )}
+      {displayRows.map((row) => {
+        const key = row.ids.join("→") || row.summary;
+        return (
+          <div key={key} className="mb-3">
+            <div className="d-flex flex-wrap align-items-center gap-2">
+              {row.ids.map((id, index) => {
+                // Each breadcrumb links directly to the relevant item page for quick navigation.
+                const fullName = row.names[index];
+                const shortLabel = formatDisplayName(fullName);
+                return (
+                  <React.Fragment key={`${id}-${index}`}>
+                    <a
+                      href={`/item/${id}`}
+                      className="text-decoration-none"
+                      title={fullName}
+                      aria-label={fullName}
+                    >
+                      {shortLabel}
+                    </a>
+                    {index < row.ids.length - 1 && (
+                      <span aria-hidden className="text-muted">
+                        →
+                      </span>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </div>
+            <div className="text-muted small mt-1">{row.summary}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ContainmentPathPanel;

--- a/frontend/src/app/components/SearchPanel.tsx
+++ b/frontend/src/app/components/SearchPanel.tsx
@@ -40,6 +40,7 @@ interface SearchPanelProps {
   tableName?: TableName;
   smallMode?: boolean;
   allowDelete?: boolean;
+  onRelationshipsChanged?: () => void;
 }
 
 const API_ENDPOINTS: Record<
@@ -203,6 +204,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
   tableName = "items",
   smallMode = false,
   allowDelete = false,
+  onRelationshipsChanged,
 }) => {
   const normalizedTable: TableName = tableName ?? "items";
   const isInvoiceMode = normalizedTable === "invoices";
@@ -844,6 +846,10 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
 
       await runSearch(lastQueryRef.current || query);
 
+      if (onRelationshipsChanged) {
+        onRelationshipsChanged();
+      }
+
       setModalMessage({
         title: isInvoiceMode
           ? "Invoices linked"
@@ -864,7 +870,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     } finally {
       setIsActionBusy(false);
     }
-  }, [associationBits, associationSummary, isInvoiceMode, normalizedTable, query, runSearch, selectedCount, selectedPks, targetUuid]);
+  }, [associationBits, associationSummary, isInvoiceMode, normalizedTable, query, runSearch, selectedCount, selectedPks, targetUuid, onRelationshipsChanged]);
 
   const handleUnlinkAssociation = useCallback(async () => {
     if (!targetUuid || selectedCount === 0) {
@@ -905,6 +911,10 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
 
       await runSearch(lastQueryRef.current || query);
 
+      if (onRelationshipsChanged) {
+        onRelationshipsChanged();
+      }
+
       setModalMessage({
         title: "Relationships removed",
         body:
@@ -920,7 +930,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     } finally {
       setIsActionBusy(false);
     }
-  }, [normalizedTable, query, runSearch, selectedCount, selectedPks, targetUuid]);
+  }, [normalizedTable, query, runSearch, selectedCount, selectedPks, targetUuid, onRelationshipsChanged]);
 
   const resolveThumbnail = useCallback((row: SearchRow): string => {
     if (smallMode || normalizedTable !== "items") {


### PR DESCRIPTION
## Summary
- add containment path query helpers and an API endpoint for retrieving all container paths for an item
- expose a containment path panel on the item page that refreshes whenever relationships change
- update the search panel to notify listeners after containment changes so dependent UI can refresh

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dca5944100832b875741de8a8370d4