### PR TITLE
Fix containment paths fetch to use relative URL

### DIFF
--- a/frontend/src/app/components/ContainmentPathPanel.tsx
+++ b/frontend/src/app/components/ContainmentPathPanel.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
 
-import { API_BASE } from "../api";
-
 interface ContainmentPathEntry {
   path: string[];
   names: string[];
@@ -63,10 +61,13 @@ const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
       setLoading(true);
       setErrorMessage(null);
       try {
-        const response = await fetch(
-          `${API_BASE}/api/containmentpaths?target_uuid=${encodeURIComponent(targetUuid)}`,
-          { signal: controller.signal, credentials: "include" }
-        );
+        const endpoint = `/api/containmentpaths?target_uuid=${encodeURIComponent(targetUuid)}`;
+        // Using a relative URL ensures we share the same origin as the login session,
+        // so authentication cookies are included consistently by the browser.
+        const response = await fetch(endpoint, {
+          signal: controller.signal,
+          credentials: "include",
+        });
         let payload: any = null;
         try {
           payload = await response.json();


### PR DESCRIPTION
## Summary
- update the containment path panel to call the API with a relative URL so it shares the authenticated origin
- remove the unused API_BASE import and document why the request stays relative for clarity

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dcadffc1d8832b88bf885b65b4c133