### PR TITLE
Log failures for background async jobs

### DIFF
--- a/backend/app/job_manager.py
+++ b/backend/app/job_manager.py
@@ -146,6 +146,14 @@ class AsyncJob:
             self._exception = exc
             self._error = str(exc) or exc.__class__.__name__
             self._result = None
+            # Record the failure immediately so silent background errors can be diagnosed.
+            logger = getattr(self._manager, "_logger", None)
+            if logger is not None:
+                logger.exception(
+                    "Async job %s failed while processing context %s.",
+                    self._job_id,
+                    self._context,
+                )
 
     def is_busy(self) -> bool:
         return self._started and not self._done_event.is_set()


### PR DESCRIPTION
## Summary
- ensure async background jobs log exceptions immediately so silent failures are visible

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dd8c628cc8832bbbecd4a96b9b1756