### PR TITLE
Add high level library summary to import gathering script

### DIFF
--- a/scripts/py_imports_gather.py
+++ b/scripts/py_imports_gather.py
@@ -3,7 +3,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Set
 
 # Regular expression designed to capture both simple 'import' statements and
 # 'from ... import ...' statements. The pattern operates in MULTILINE mode so
@@ -37,6 +37,55 @@ def format_import_output(python_file: Path, import_statements: Iterable[str]) ->
         formatted_results.append(f"{relative_path}: {statement}")
     return formatted_results
 
+def parse_import_targets(import_statement: str) -> List[str]:
+    """Return every module path referenced by a single import statement."""
+    cleaned_statement = import_statement.strip()
+    targets: List[str] = []
+    if cleaned_statement.startswith('from '):
+        # Extract the module portion that follows the "from" keyword and
+        # precedes the "import" keyword. Relative imports (those beginning
+        # with a period) are ignored because they refer to local modules.
+        source_details = cleaned_statement[5:].split(' import ', 1)
+        if len(source_details) == 2:
+            module_path = source_details[0].strip()
+            if module_path and not module_path.startswith('.'):
+                targets.append(module_path)
+        return targets
+    if cleaned_statement.startswith('import '):
+        # Split multiple imports separated by commas, respecting any aliases
+        # by capturing only the portion before the "as" keyword.
+        imported_modules = cleaned_statement[7:]
+        for module_fragment in imported_modules.split(','):
+            leading_module = module_fragment.strip().split(' as ', 1)[0].strip()
+            if leading_module and not leading_module.startswith('.'):
+                targets.append(leading_module)
+    return targets
+
+def collect_high_level_library_names(formatted_results: Iterable[str], backend_root: Path) -> List[str]:
+    """Create a sorted list of unique top-level libraries from formatted import data."""
+    backend_directories: Set[str] = set()
+    if backend_root.exists():
+        for backend_child in backend_root.iterdir():
+            if backend_child.is_dir():
+                backend_directories.add(backend_child.name)
+
+    discovered_libraries: Set[str] = set()
+    for result_line in formatted_results:
+        try:
+            _, import_statement = result_line.split(': ', 1)
+        except ValueError:
+            # If the line cannot be split, skip it while keeping the script resilient.
+            continue
+        for target in parse_import_targets(import_statement):
+            high_level_name = target.split('.', 1)[0].strip()
+            if not high_level_name:
+                continue
+            if high_level_name in backend_directories:
+                continue
+            discovered_libraries.add(high_level_name)
+
+    return sorted(discovered_libraries)
+
 def main() -> None:
     """Locate and print every import statement discovered in project Python files."""
     project_root = Path.cwd()
@@ -49,6 +98,15 @@ def main() -> None:
     # and makes downstream consumption or diffing more predictable.
     for line in sorted(all_results):
         print(line)
+
+    # After enumerating each import statement, present the unique high-level
+    # libraries referenced throughout the codebase to support quick auditing.
+    library_names = collect_high_level_library_names(all_results, project_root / 'backend')
+    if library_names:
+        print()
+        print('High level imported libraries (excluding backend directories):')
+        for library_name in library_names:
+            print(library_name)
 
 if __name__ == '__main__':
     # The script is intended to be executed from the repository root so that


### PR DESCRIPTION
## Summary
- add helper utilities that parse import statements into explicit module targets
- derive unique high level library names while skipping backend directories
- extend the script output with a readable summary list of those libraries

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68dd8fec9a28832bac3ae67bc9574ade