### PR TITLE
Fix EmbeddingAi imports for app runtime

### DIFF
--- a/backend/app/embeddings.py
+++ b/backend/app/embeddings.py
@@ -16,7 +16,8 @@ from .db import get_engine, get_db_item_as_dict, get_or_create_session
 from .assoc_helper import CONTAINMENT_BIT
 from .helpers import normalize_pg_uuid
 from .search_expression import SearchQuery, get_sql_order_and_limit
-from ..automation.ai_helpers import EmbeddingAi
+# Use an absolute import because the Flask launcher treats "app" as the root package.
+from automation.ai_helpers import EmbeddingAi
 from .containment_path import get_all_containments
 
 log = logging.getLogger(__name__)

--- a/backend/app/metatext.py
+++ b/backend/app/metatext.py
@@ -18,7 +18,8 @@ from nltk.corpus import wordnet
 from .db import get_engine, get_db_item_as_dict, get_or_create_session
 from .helpers import deduplicate_preserving_order, split_words, normalize_pg_uuid, levenshtein_match
 from .config_loader import load_app_config
-from ..automation.ai_helpers import EmbeddingAi
+# Use an absolute import because the Flask launcher treats "app" as the root package.
+from automation.ai_helpers import EmbeddingAi
 
 TAG_WORDS_TABLE_NAME = "tag_words"
 


### PR DESCRIPTION
## Summary
- switch the EmbeddingAi imports in the embeddings and metatext modules to absolute paths so they resolve when Flask loads the app package
- add inline documentation explaining the absolute import requirement for this runtime configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2e3320d8832bb819b2587d1d7699