### PR TITLE
Add move_item helper to manage containment transitions

### DIFF
--- a/backend/app/assoc_helper.py
+++ b/backend/app/assoc_helper.py
@@ -7,11 +7,12 @@ the `assoc_type` is an integer represented by bits
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, List, Tuple
 
 from sqlalchemy import text
 
-from .db import get_engine
+from .db import get_engine, get_db_item_as_dict, update_db_row_by_dict
 from .helpers import normalize_pg_uuid
 from .history import log_history
 # from .embeddings import update_embeddings_for_item # circular import if done here
@@ -283,3 +284,212 @@ def set_item_relationship(first_identifier: Any, second_identifier: Any, assoc_t
             "after": x
         })
     return x
+
+
+def move_item(item_identifier: Any, target_container_identifier: Any) -> Dict[str, Any]:
+    """Move an item to a different container while keeping containment history tidy."""
+    # Normalize identifiers so downstream comparisons remain reliable.
+    try:
+        normalized_item_id = normalize_pg_uuid(str(item_identifier))
+        normalized_target_id = normalize_pg_uuid(str(target_container_identifier))
+    except Exception as exc:
+        log.debug(
+            "move_item: unable to normalize identifiers %r and %r: %s",
+            item_identifier,
+            target_container_identifier,
+            exc,
+        )
+        return {"ok": False, "error": "Invalid item or container identifier."}
+
+    engine = get_engine()
+
+    # Cache lookups so we do not query the same item repeatedly when examining paths.
+    item_cache: Dict[str, Optional[Dict[str, Any]]] = {}
+
+    def _load_item_dict(identifier: str) -> Optional[Dict[str, Any]]:
+        """Fetch and cache item rows to avoid repeated queries."""
+        if not identifier:
+            return None
+        if identifier in item_cache:
+            return item_cache[identifier]
+        try:
+            row = get_db_item_as_dict(engine, "items", identifier)
+        except Exception:
+            log.debug("move_item: failed to load item %s while evaluating containment paths", identifier)
+            item_cache[identifier] = None
+            return None
+        item_cache[identifier] = dict(row)
+        return item_cache[identifier]
+
+    moving_item = _load_item_dict(normalized_item_id)
+    if not moving_item:
+        return {"ok": False, "error": "Item to move could not be found."}
+
+    target_container = _load_item_dict(normalized_target_id)
+    if not target_container:
+        return {"ok": False, "error": "Target container could not be found."}
+
+    # Ensure our cache retains the canonical copies for the items we already resolved.
+    item_cache[normalized_item_id] = moving_item
+    item_cache[normalized_target_id] = target_container
+
+    try:
+        from .containment_path import fetch_containment_paths
+
+        containment_paths = fetch_containment_paths(normalized_item_id)
+    except Exception:
+        log.exception("move_item: failed to fetch containment paths for %s", normalized_item_id)
+        containment_paths = []
+
+    selected_path: Optional[Dict[str, Any]] = None
+    existing_container_id: Optional[str] = None
+    deletion_reason: Optional[str] = None
+
+    if containment_paths:
+        fixed_paths = [path for path in containment_paths if path.get("terminal_is_fixed_location")]
+        if len(fixed_paths) == 1:
+            candidate = fixed_paths[0]
+            sequence = list(candidate.get("path") or [])
+            if sequence:
+                try:
+                    existing_container_id = normalize_pg_uuid(str(sequence[0]))
+                    selected_path = candidate
+                    deletion_reason = "unique_fixed_location_path"
+                except Exception:
+                    log.debug("move_item: skipped fixed-location path with invalid identifier")
+        elif len(fixed_paths) > 1:
+            deletion_reason = "multiple_fixed_location_paths"
+        else:
+            filtered_candidates: List[Tuple[Dict[str, Any], str, Dict[str, Any]]] = []
+            for candidate in containment_paths:
+                sequence = list(candidate.get("path") or [])
+                if not sequence:
+                    continue
+                try:
+                    first_identifier = normalize_pg_uuid(str(sequence[0]))
+                    terminal_identifier = normalize_pg_uuid(str(sequence[-1]))
+                except Exception:
+                    continue
+                first_item = _load_item_dict(first_identifier)
+                if not first_item or not (first_item.get("is_container") or first_item.get("is_collection")):
+                    continue
+                terminal_item = _load_item_dict(terminal_identifier)
+                if not terminal_item or not (terminal_item.get("is_container") or terminal_item.get("is_collection")):
+                    continue
+                filtered_candidates.append((candidate, first_identifier, first_item))
+            if len(filtered_candidates) == 1:
+                selected_path, existing_container_id, _ = filtered_candidates[0]
+                deletion_reason = "unique_container_path"
+            elif len(filtered_candidates) > 1:
+                large_candidates = [entry for entry in filtered_candidates if entry[2].get("is_large")]
+                if len(large_candidates) == 1:
+                    selected_path, existing_container_id, _ = large_candidates[0]
+                    deletion_reason = "large_container_path"
+
+    removed_relationship: Optional[Dict[str, Any]] = None
+    previous_container: Optional[Dict[str, Any]] = None
+    if selected_path and existing_container_id:
+        previous_container = _load_item_dict(existing_container_id)
+        relationship = get_item_relationship(normalized_item_id, existing_container_id)
+        if relationship and int(relationship.get("assoc_type") or 0) & CONTAINMENT_BIT:
+            try:
+                from .items import delete_item_relationship
+
+                removed_relationship = delete_item_relationship(relationship.get("id"))
+            except Exception:
+                log.exception("move_item: failed to delete containment relationship %s", relationship.get("id"))
+        else:
+            log.debug(
+                "move_item: no containment relationship found between %s and %s",
+                normalized_item_id,
+                existing_container_id,
+            )
+
+    created_relationship = set_item_relationship(normalized_item_id, normalized_target_id, CONTAINMENT_BIT)
+
+    timestamp_text = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _format_descriptor(row: Optional[Dict[str, Any]]) -> str:
+        """Return a human-friendly descriptor prioritizing the slug."""
+        if not row:
+            return "unknown"
+        slug_value = str(row.get("slug") or "").strip()
+        if slug_value:
+            return slug_value
+        name_value = str(row.get("name") or "").strip()
+        if name_value:
+            return name_value
+        return str(row.get("id") or "unknown")
+
+    def _extract_slug(row: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Return the slug or identifier for history logging."""
+        if not row:
+            return None
+        slug_value = str(row.get("slug") or "").strip()
+        if slug_value:
+            return slug_value
+        identifier_value = row.get("id")
+        return str(identifier_value) if identifier_value is not None else None
+
+    from_descriptor = _format_descriptor(previous_container)
+    to_descriptor = _format_descriptor(target_container)
+    item_descriptor = _format_descriptor(moving_item)
+
+    if removed_relationship:
+        remarks_line = f"[{timestamp_text}] moved item from {from_descriptor} to {to_descriptor}."
+    else:
+        remarks_line = f"[{timestamp_text}] moved item to {to_descriptor}."
+
+    existing_remarks = str(moving_item.get("remarks") or "").rstrip()
+    if existing_remarks:
+        updated_remarks = f"{existing_remarks}\\r\\n{remarks_line}"
+    else:
+        updated_remarks = remarks_line
+
+    update_payload, _status_code = update_db_row_by_dict(
+        engine=engine,
+        table="items",
+        uuid=normalized_item_id,
+        data={"remarks": updated_remarks},
+        fuzzy=False,
+    )
+    if not (isinstance(update_payload, dict) and update_payload.get("ok")):
+        log.debug("move_item: remarks update returned non-success payload: %s", update_payload)
+
+    history_meta = {
+        "item": _extract_slug(moving_item),
+        "from": _extract_slug(previous_container) if removed_relationship else None,
+        "to": _extract_slug(target_container),
+    }
+    log_history(
+        item_id_1=normalized_item_id,
+        item_id_2=normalized_target_id,
+        event="moved item",
+        meta=history_meta,
+    )
+
+    try:
+        from .embeddings import update_embeddings_for_container
+
+        embedding_targets: Dict[str, Dict[str, Any]] = {}
+        for candidate in [moving_item, previous_container, target_container]:
+            if not candidate:
+                continue
+            if candidate.get("is_container") or candidate.get("is_collection"):
+                candidate_id = str(candidate.get("id") or "")
+                if candidate_id:
+                    embedding_targets[candidate_id] = candidate
+        for candidate in embedding_targets.values():
+            try:
+                update_embeddings_for_container(candidate)
+            except Exception:
+                log.exception("move_item: failed to refresh container embeddings for %s", candidate.get("id"))
+    except Exception:
+        log.exception("move_item: container embedding update failed to initialize")
+
+    return {
+        "ok": True,
+        "deleted_relationship": removed_relationship,
+        "created_relationship": created_relationship,
+        "deletion_reason": deletion_reason,
+    }


### PR DESCRIPTION
## Summary
- extend assoc_helper imports to cover datetime utilities and database helpers
- implement `move_item` to relocate items between containers, update remarks, history, and embeddings

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68dec8f747e4832b91ca46ad11e2f1e2