### PR TITLE
Add move item controls to search panel

### DIFF
--- a/frontend/src/pages/ItemPage.tsx
+++ b/frontend/src/pages/ItemPage.tsx
@@ -679,6 +679,7 @@ const ItemPage: React.FC = () => {
         </div>
         <SearchPanel
           targetUuid={targetUuid}
+          targetSlug={item.slug ?? null}
           refreshToken={refreshToken}
           tableName="items"
           onRelationshipsChanged={handleContainmentRelationshipsChanged}
@@ -695,7 +696,7 @@ const ItemPage: React.FC = () => {
         <div className="d-flex align-items-center justify-content-between mb-2">
           <h2 className="h5 mb-0">Relevant Invoices</h2>
         </div>
-        <SearchPanel targetUuid={targetUuid} refreshToken={refreshToken} tableName="invoices" />
+        <SearchPanel targetUuid={targetUuid} targetSlug={item.slug ?? null} refreshToken={refreshToken} tableName="invoices" />
       </div>
 
       {/* Footer meta */}


### PR DESCRIPTION
## Summary
- add move links to the item search footer when a target and single selection are present, using the item slugs for clarity
- hook the new controls to a `/api/moveitem` endpoint that wraps the existing `move_item` helper and reports success or failure
- pass the current item slug to the search panel so the footer can label the move actions accurately

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ded75aa8c4832b9309f0a4e62c95da