### PR TITLE
Fix embedding row mapping conversion

### DIFF
--- a/backend/app/embeddings.py
+++ b/backend/app/embeddings.py
@@ -284,7 +284,8 @@ def update_embeddings_for_item(item_or_identifier: Union[Mapping[str, Any], str,
         except Exception:
             log.exception("Failed to update container embeddings for item %s", item_uuid)
 
-    return dict(existing) if existing else None
+    # SQLAlchemy Row objects expose a mapping with column names; using it avoids tuple conversion issues.
+    return dict(existing._mapping) if existing else None
 
 
 def summarize_container_embeddings(container_uuid,


### PR DESCRIPTION
## Summary
- ensure embedding refresh uses the SQLAlchemy row mapping to build a dictionary without tuple conversion errors

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df834baa0c832b94ebdb0d1ad98f73