### PR TITLE
Ensure storage chain links expose full names via alt text

### DIFF
--- a/frontend/src/app/components/ContainmentPathPanel.tsx
+++ b/frontend/src/app/components/ContainmentPathPanel.tsx
@@ -184,13 +184,18 @@ const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
                 // Each breadcrumb links directly to the relevant item page for quick navigation.
                 const fullName = row.names[index];
                 const shortLabel = formatDisplayName(fullName);
+                const isTruncated = shortLabel !== fullName;
+                // Provide accessible context for truncated labels so that assistive technology
+                // and hover tooltips expose the complete item name within the storage chain.
+                const accessibleLabel = fullName;
+                const tooltipText = isTruncated ? fullName : undefined;
                 return (
                   <React.Fragment key={`${id}-${index}`}>
                     <a
                       href={`/item/${id}`}
                       className="text-decoration-none"
-                      title={fullName}
-                      aria-label={fullName}
+                      title={tooltipText}
+                      aria-label={accessibleLabel}
                     >
                       {shortLabel}
                     </a>


### PR DESCRIPTION
## Summary
- add context-aware accessible labeling for storage chain breadcrumbs
- provide full-name tooltips only when the visible label is truncated

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df8a4c577c832b89fbd9e7a3a71f9f