### PR TITLE
Stop containment path recursion past fixed locations

### DIFF
--- a/backend/app/containment_path.py
+++ b/backend/app/containment_path.py
@@ -92,6 +92,11 @@ def fetch_containment_paths(item_identifier: Any) -> List[dict[str, Any]]:
                     ELSE r.item_id
                 END
             WHERE NOT neighbor.id = ANY(containment_tree.path)
+              AND (
+                  -- Prevent recursion from walking past fixed locations unless we are still evaluating the original target item.
+                  NOT containment_tree.is_fixed_location
+                  OR containment_tree.current_id = :target
+              )
         ),
         terminal_paths AS (
             SELECT


### PR DESCRIPTION
## Summary
- prevent containment path recursion from traversing beyond fixed location items unless they are the initial target
- document the guard directly in the recursive CTE for clarity

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68df93106fc8832b8633abd7c7b1a63d