### PR TITLE
Filter containment paths for fixed items

### DIFF
--- a/frontend/src/pages/ItemPage.tsx
+++ b/frontend/src/pages/ItemPage.tsx
@@ -689,6 +689,7 @@ const ItemPage: React.FC = () => {
       <ContainmentPathPanel
         targetUuid={containmentTargetUuid}
         refreshSignal={containmentRefreshToken}
+        targetIsFixedLocation={Boolean(item.is_fixed_location)}
       />
 
       {/* Relevant Invoices */}


### PR DESCRIPTION
## Summary
- pass the target item's fixed-location flag into the containment path panel
- filter containment paths to only display fixed-location destinations when required and explain hidden results
- keep the standard messaging for unfixed items while clarifying empty states for fixed items

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68df96b4edd4832b9f2c1b6aab001bbf