### PR TITLE
Add collapsible relationship panels on item page

### DIFF
--- a/backend/app/assoc_helper.py
+++ b/backend/app/assoc_helper.py
@@ -359,6 +359,8 @@ def move_item(
             sequence = list(candidate.get("path") or [])
             if sequence:
                 try:
+                    # Each containment path already omits the moving item itself, so the first
+                    # element identifies the immediate container that currently holds the item.
                     existing_container_id = normalize_pg_uuid(str(sequence[0]))
                     selected_path = candidate
                     deletion_reason = "unique_fixed_location_path"

--- a/frontend/src/app/components/ContainmentPathPanel.tsx
+++ b/frontend/src/app/components/ContainmentPathPanel.tsx
@@ -21,8 +21,8 @@ interface ContainmentPathPanelProps {
 interface DisplayRow {
   ids: string[];
   names: string[];
-  summary: string;
   terminalIsFixed: boolean;
+  terminalIsDeadEnd: boolean;
 }
 
 const MAX_DISPLAY_NAME_LENGTH = 10;
@@ -151,14 +151,12 @@ const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
         return;
       }
       const isFixed = Boolean(entry.terminal_is_fixed_location);
-      const summary = isFixed
-        ? "🏠 Fixed location reached at the end of this path."
-        : "🔚 No further containment relationships beyond this point.";
+      const isDeadEnd = Boolean(entry.terminal_is_dead_end);
       rows.push({
         ids: idsForDisplay,
         names: namesForDisplay,
-        summary,
         terminalIsFixed: isFixed,
+        terminalIsDeadEnd: isDeadEnd,
       });
     });
     let rowsToDisplay = rows;
@@ -174,10 +172,9 @@ const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
   const shouldExplainFiltering = targetIsFixedLocation && filteredOutCount > 0;
 
   return (
-    <div className="mb-4">
-      <div className="d-flex align-items-center justify-content-between mb-2">
-        <h2 className="h5 mb-0">Storage Chain</h2>
-      </div>
+    <div>
+      {/* The surrounding page is responsible for rendering the section heading so this
+          panel focuses solely on the informative content. */}
       {!targetUuid && (
         <div className="text-muted">Save the item to explore containment paths.</div>
       )}
@@ -207,10 +204,22 @@ const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
         </div>
       )}
       {rowsToDisplay.map((row) => {
-        const key = row.ids.join("→") || row.summary;
+        const key = row.ids.join("→") || (row.terminalIsFixed ? "fixed" : "dead-end");
+        const indicatorEmoji = row.terminalIsFixed ? "🏠" : "🔚";
+        const indicatorDescription = row.terminalIsFixed
+          ? "This path ends at a fixed location."
+          : row.terminalIsDeadEnd
+            ? "This path currently has no further containment options."
+            : "This path continues beyond the listed containers.";
         return (
-          <div key={key} className="mb-3">
-            <div className="d-flex flex-wrap align-items-center gap-2">
+          <div key={key} className="mb-2">
+            <div className="d-flex align-items-center gap-2 flex-wrap">
+              <span aria-hidden className="fs-5">
+                {indicatorEmoji}
+              </span>
+              <span className="visually-hidden">
+                {indicatorDescription}
+              </span>
               {row.ids.map((id, index) => {
                 // Each breadcrumb links directly to the relevant item page for quick navigation.
                 const fullName = row.names[index];
@@ -239,7 +248,6 @@ const ContainmentPathPanel: React.FC<ContainmentPathPanelProps> = ({
                 );
               })}
             </div>
-            <div className="text-muted small mt-1">{row.summary}</div>
           </div>
         );
       })}


### PR DESCRIPTION
## Summary
- add a local accordion-style wrapper on the item page so the search and containment panels can be collapsed independently
- update the containment path panel layout to keep path details on a single line with the status emoji leading the row
- document the expectation in move_item that containment paths omit the moving item itself

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e03072fc20832b94318cf8e2bd79af