### PR TITLE
Add tree root flag handling for items

### DIFF
--- a/backend/app/items.py
+++ b/backend/app/items.py
@@ -448,7 +448,8 @@ def save_item_api():
         if col in DEFAULTABLE_COLUMNS:
             payload.pop(col)
 
-    if payload.get("is_collection") is True:
+    if payload.get("is_collection") is True or payload.get("is_tree_root") is True:
+        # Ensure special groupings (collections and tree roots) always count as containers
         payload["is_container"] = True
 
     before_item = None
@@ -608,7 +609,8 @@ def insert_item(
         # False.  (Truthiness is preserved; only ``None`` triggers the default.)
         data["is_staging"] = True
 
-    if data.get("is_collection") is True:
+    if data.get("is_collection") is True or data.get("is_tree_root") is True:
+        # Ensure special groupings (collections and tree roots) always count as containers
         data["is_container"] = True
 
     # remove null creation date so the DB fills it in with now() automatically

--- a/frontend/src/pages/ItemPage.tsx
+++ b/frontend/src/pages/ItemPage.tsx
@@ -20,6 +20,7 @@ export interface ItemDto {
   date_last_modified?: string | null; // ISO timestamp
   is_container?: boolean;
   is_collection?: boolean;
+  is_tree_root?: boolean;
   is_large?: boolean;
   is_small?: boolean;
   is_fixed_location?: boolean;
@@ -49,6 +50,7 @@ const EMPTY_ITEM: ItemDto = {
   source: "",
   is_container: false,
   is_collection: false,
+  is_tree_root: false,
   is_large: false,
   is_small: false,
   is_fixed_location: false,
@@ -136,6 +138,7 @@ function formatPinTimestamp(value?: string | null): { readable: string; instant:
 const booleanFlags = [
   { key: "is_container",      emoji: "📦", label: "Container" },
   { key: "is_collection",     emoji: "🗃️", label: "Collection" },
+  { key: "is_tree_root",     emoji: "🌳", label: "Tree Root" }, // Tree roots represent the anchor container in a hierarchy
   { key: "is_large",          emoji: "🐘", label: "Large" },
   { key: "is_small",          emoji: "🐜", label: "Small" },
   { key: "is_fixed_location", emoji: "🛏️", label: "Fixed Location" },


### PR DESCRIPTION
## Summary
- add the new tree root flag to the item editor with the 🌳 indicator and default value
- automatically mark items as containers when either the collection or tree root flags are selected

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e056004398832b891548416e2b15f7