### PR TITLE
Fix Gmail utility imports when executed directly

### DIFF
--- a/backend/email_utils/gmail.py
+++ b/backend/email_utils/gmail.py
@@ -12,12 +12,15 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
-# We need the project root on sys.path so that absolute imports work when the
-# file is executed directly from different directories.
+# We need both the repository root and the backend package directory on sys.path so that
+# absolute imports work when the file is executed directly from different directories.
+# The backend path is added first because modules such as 'app' live directly beneath it.
 _CURRENT_FILE = Path(__file__).resolve()
 _PROJECT_ROOT = _CURRENT_FILE.parents[2]
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
+_BACKEND_PACKAGE_ROOT = _CURRENT_FILE.parents[1]
+for _path_string in (str(_BACKEND_PACKAGE_ROOT), str(_PROJECT_ROOT)):
+    if _path_string not in sys.path:
+        sys.path.insert(0, _path_string)
 
 from sqlalchemy import text
 


### PR DESCRIPTION
## Summary
- ensure the Gmail polling script prepends the backend package directory to sys.path so absolute imports resolve when run as a standalone module

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e0b79f8b84832ba562bc876c020dcd