### PR TITLE
Fix TreeView mounted flag initialization

### DIFF
--- a/frontend/src/app/components/TreeView.tsx
+++ b/frontend/src/app/components/TreeView.tsx
@@ -277,6 +277,9 @@ const TreeView: React.FC = () => {
   const mountedRef = useRef<boolean>(true);
 
   useEffect(() => {
+    // React's Strict Mode intentionally mounts components twice in development, so we reset
+    // the mounted flag on every entry to guarantee asynchronous responses can update state.
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       if (clickTimerRef.current !== null) {


### PR DESCRIPTION
## Summary
- ensure the TreeView component resets its mounted flag at the start of each mount so asynchronous fetches update the UI
- document the Strict Mode double-mount behavior directly in the effect for future maintainers

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e0c8017540832b8a35bccdb6af60c1