### PR TITLE
Handle tuple response from HTML parser

### DIFF
--- a/backend/automation/html_dom_finder.py
+++ b/backend/automation/html_dom_finder.py
@@ -208,7 +208,14 @@ def group_repeating_siblings(root):
     return candidates
 
 def analyze(html, base_url=None, topn=5):
-    root = parse_unknown_html_or_mhtml(html)
+    parsed_result = parse_unknown_html_or_mhtml(html)
+    # The helper returns both the parsed DOM root and a textual format hint;
+    # only the root element is required for downstream analysis, so unwrap it
+    # defensively in case future helpers alter the return contract.
+    if isinstance(parsed_result, tuple):
+        root, _detected_format = parsed_result
+    else:
+        root = parsed_result
     root = sanitize_dom(root)
     root.make_links_absolute(base_url) if base_url else None
 


### PR DESCRIPTION
## Summary
- unwrap the tuple returned by `parse_unknown_html_or_mhtml` before sanitizing the DOM
- add explanatory comments clarifying why the tuple must be unpacked defensively

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e0e9db05fc832b81a401da8e7742c6