### PR TITLE
Ensure prefilled search URLs run automatically

### DIFF
--- a/frontend/src/pages/LedgerSearchPage.tsx
+++ b/frontend/src/pages/LedgerSearchPage.tsx
@@ -1,37 +1,49 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
-
-import InvoiceUploaderPanel from "../app/components/InvoiceUploaderPanel";
-import SearchPanel from "../app/components/SearchPanel";
-
-const LedgerSearchPage: React.FC = () => {
-  const { xyz } = useParams<{ xyz?: string }>();
-  const prefilled = useMemo(() => (xyz ? decodeURIComponent(xyz) : ""), [xyz]);
-  const [searchPrefill, setSearchPrefill] = useState(prefilled);
-
-  useEffect(() => {
-    setSearchPrefill(prefilled);
-  }, [prefilled]);
-
-  return (
-    <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
-      <SearchPanel
-        displayedTitle="Search Ledger"
-        prefilledQuery={searchPrefill}
-        tableName="invoices"
-        allowDelete
-      />
-
-      <InvoiceUploaderPanel
-        onSearchPrefillSuggested={(query) => {
-          // Provide the parent search panel with the recommended query so users immediately see fresh results.
-          setSearchPrefill(query);
-        }}
-        // Email polling is now automated, so hide the manual checker panel.
-        showCheckEmailPanel={false}
-      />
-    </div>
-  );
-};
-
-export default LedgerSearchPage;
+import React, { useEffect, useMemo, useState } from "react";
+import { useLocation, useParams } from "react-router-dom";
+
+import InvoiceUploaderPanel from "../app/components/InvoiceUploaderPanel";
+import SearchPanel from "../app/components/SearchPanel";
+
+const LedgerSearchPage: React.FC = () => {
+  const { xyz } = useParams<{ xyz?: string }>();
+  const location = useLocation();
+
+  const prefilled = useMemo(() => {
+    const pathPrefill = xyz ? decodeURIComponent(xyz) : "";
+    const params = new URLSearchParams(location.search);
+    const queryPrefill = params.get("q") ?? params.get("query") ?? "";
+    // Favor explicit query-string parameters so copied URLs trigger their intended searches immediately.
+    if (queryPrefill) {
+      return queryPrefill;
+    }
+    return pathPrefill;
+  }, [location.search, xyz]);
+  const [searchPrefill, setSearchPrefill] = useState(prefilled);
+
+  useEffect(() => {
+    // Propagate the resolved prefill value so the search panel can execute matching requests when the URL changes.
+    setSearchPrefill(prefilled);
+  }, [prefilled]);
+
+  return (
+    <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
+      <SearchPanel
+        displayedTitle="Search Ledger"
+        prefilledQuery={searchPrefill}
+        tableName="invoices"
+        allowDelete
+      />
+
+      <InvoiceUploaderPanel
+        onSearchPrefillSuggested={(query) => {
+          // Provide the parent search panel with the recommended query so users immediately see fresh results.
+          setSearchPrefill(query);
+        }}
+        // Email polling is now automated, so hide the manual checker panel.
+        showCheckEmailPanel={false}
+      />
+    </div>
+  );
+};
+
+export default LedgerSearchPage;

--- a/frontend/src/pages/SearchItemsPage.tsx
+++ b/frontend/src/pages/SearchItemsPage.tsx
@@ -1,24 +1,32 @@
-import React, { useMemo } from "react";
-import { useParams } from "react-router-dom";
-
-import SearchPanel from "../app/components/SearchPanel";
-import TreeView from "../app/components/TreeView";
-
-const SearchItemsPage: React.FC = () => {
-  const { xyz } = useParams<{ xyz?: string }>();
-  const prefilled = useMemo(() => (xyz ? decodeURIComponent(xyz) : ""), [xyz]);
-
-  return (
-    <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
-      <SearchPanel
-        displayedTitle="Search Inventory Items"
-        prefilledQuery={prefilled}
-        tableName="items"
-        allowDelete
-      />
-      <TreeView />
-    </div>
-  );
-};
-
-export default SearchItemsPage;
+import React, { useMemo } from "react";
+import { useLocation, useParams } from "react-router-dom";
+
+import SearchPanel from "../app/components/SearchPanel";
+import TreeView from "../app/components/TreeView";
+
+const SearchItemsPage: React.FC = () => {
+  const { xyz } = useParams<{ xyz?: string }>();
+  const location = useLocation();
+
+  const prefilled = useMemo(() => {
+    const pathPrefill = xyz ? decodeURIComponent(xyz) : "";
+    const params = new URLSearchParams(location.search);
+    const queryPrefill = params.get("q") ?? params.get("query") ?? "";
+    // Prefer query-string values so deep links like /search-items?q=red launch searches automatically.
+    return queryPrefill || pathPrefill;
+  }, [location.search, xyz]);
+
+  return (
+    <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
+      <SearchPanel
+        displayedTitle="Search Inventory Items"
+        prefilledQuery={prefilled}
+        tableName="items"
+        allowDelete
+      />
+      <TreeView />
+    </div>
+  );
+};
+
+export default SearchItemsPage;


### PR DESCRIPTION
## Summary
- ensure the ledger search page resolves search prefills from either the path segment or query string so deep links immediately run
- update the item search page to honor prefilled query parameters from the URL so shared links execute automatically

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e1ec6a35a0832bb8836ba0d2f93d04