### PR TITLE
Ensure search pages trigger URL-driven queries

### DIFF
--- a/frontend/src/pages/LedgerSearchPage.tsx
+++ b/frontend/src/pages/LedgerSearchPage.tsx
@@ -1,28 +1,86 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { useLocation, useParams } from "react-router-dom";
-
-import InvoiceUploaderPanel from "../app/components/InvoiceUploaderPanel";
-import SearchPanel from "../app/components/SearchPanel";
-
-const LedgerSearchPage: React.FC = () => {
-  const { xyz } = useParams<{ xyz?: string }>();
-  const location = useLocation();
-
-  const prefilled = useMemo(() => {
-    const pathPrefill = xyz ? decodeURIComponent(xyz) : "";
-    const params = new URLSearchParams(location.search);
-    const queryPrefill = params.get("q") ?? params.get("query") ?? "";
-    // Favor explicit query-string parameters so copied URLs trigger their intended searches immediately.
-    if (queryPrefill) {
-      return queryPrefill;
-    }
-    return pathPrefill;
-  }, [location.search, xyz]);
-  const [searchPrefill, setSearchPrefill] = useState(prefilled);
-
-  useEffect(() => {
-    // Propagate the resolved prefill value so the search panel can execute matching requests when the URL changes.
-    setSearchPrefill(prefilled);
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation, useParams } from "react-router-dom";
+
+import InvoiceUploaderPanel from "../app/components/InvoiceUploaderPanel";
+import SearchPanel from "../app/components/SearchPanel";
+
+interface PrefillState {
+  query: string;
+  token: number;
+}
+
+const LedgerSearchPage: React.FC = () => {
+  const { xyz } = useParams<{ xyz?: string }>();
+  const location = useLocation();
+
+  const resolvedPrefill = useMemo(() => {
+    const pathPrefill = xyz ? decodeURIComponent(xyz) : "";
+    const params = new URLSearchParams(location.search);
+    const queryPrefill = params.get("q") ?? params.get("query") ?? "";
+    // Favor explicit query-string parameters so copied URLs trigger their intended searches immediately.
+    if (queryPrefill) {
+      return queryPrefill;
+    }
+    return pathPrefill;
+  }, [location.search, xyz]);
+
+  const [prefillState, setPrefillState] = useState<PrefillState>(() => ({
+    // Track both the query text and a monotonically increasing token so we can trigger refreshes when needed.
+    query: resolvedPrefill,
+    token: resolvedPrefill ? 1 : 0,
+  }));
+
+  useEffect(() => {
+    setPrefillState((previous) => {
+      if (previous.query === resolvedPrefill) {
+        return previous;
+      }
+      // Increment the token whenever the URL-derived query changes so SearchPanel reruns the associated backend search.
+      return {
+        query: resolvedPrefill,
+        token: previous.token + 1,
+      };
+    });
+  }, [resolvedPrefill]);
+
+  const handleSearchPrefillSuggested = useCallback((query: string) => {
+    setPrefillState((previous) => {
+      if (previous.query === query) {
+        return previous;
+      }
+      // Each suggestion updates the refresh token so SearchPanel initiates a new backend request immediately.
+      return {
+        query,
+        token: previous.token + 1,
+      };
+    });
+  }, []);
+
+  const { query: searchPrefill, token: refreshToken } = prefillState;
+
+  return (
+    <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
+      <SearchPanel
+        displayedTitle="Search Ledger"
+        prefilledQuery={searchPrefill}
+        refreshToken={refreshToken}
+        tableName="invoices"
+        allowDelete
+      />
+
+      <InvoiceUploaderPanel
+        onSearchPrefillSuggested={(query) => {
+          handleSearchPrefillSuggested(query);
+        }}
+        // Email polling is now automated, so hide the manual checker panel.
+        showCheckEmailPanel={false}
+      />
+    </div>
+  );
+};
+
+export default LedgerSearchPage;
+
   }, [prefilled]);
 
   return (

--- a/frontend/src/pages/SearchItemsPage.tsx
+++ b/frontend/src/pages/SearchItemsPage.tsx
@@ -1,19 +1,62 @@
-import React, { useMemo } from "react";
-import { useLocation, useParams } from "react-router-dom";
-
-import SearchPanel from "../app/components/SearchPanel";
-import TreeView from "../app/components/TreeView";
-
-const SearchItemsPage: React.FC = () => {
-  const { xyz } = useParams<{ xyz?: string }>();
-  const location = useLocation();
-
-  const prefilled = useMemo(() => {
-    const pathPrefill = xyz ? decodeURIComponent(xyz) : "";
-    const params = new URLSearchParams(location.search);
-    const queryPrefill = params.get("q") ?? params.get("query") ?? "";
-    // Prefer query-string values so deep links like /search-items?q=red launch searches automatically.
-    return queryPrefill || pathPrefill;
+import React, { useEffect, useMemo, useState } from "react";
+import { useLocation, useParams } from "react-router-dom";
+
+import SearchPanel from "../app/components/SearchPanel";
+import TreeView from "../app/components/TreeView";
+
+interface PrefillState {
+  query: string;
+  token: number;
+}
+
+const SearchItemsPage: React.FC = () => {
+  const { xyz } = useParams<{ xyz?: string }>();
+  const location = useLocation();
+
+  const resolvedPrefill = useMemo(() => {
+    const pathPrefill = xyz ? decodeURIComponent(xyz) : "";
+    const params = new URLSearchParams(location.search);
+    const queryPrefill = params.get("q") ?? params.get("query") ?? "";
+    // Prefer query-string values so deep links like /search-items?q=red launch searches automatically.
+    return queryPrefill || pathPrefill;
+  }, [location.search, xyz]);
+
+  const [prefillState, setPrefillState] = useState<PrefillState>(() => ({
+    // Persist the latest resolved query alongside a counter so SearchPanel knows when a new automatic search is required.
+    query: resolvedPrefill,
+    token: resolvedPrefill ? 1 : 0,
+  }));
+
+  useEffect(() => {
+    setPrefillState((previous) => {
+      if (previous.query === resolvedPrefill) {
+        return previous;
+      }
+      // Bump the token whenever the URL changes to ensure the backend request is reissued for the new parameters.
+      return {
+        query: resolvedPrefill,
+        token: previous.token + 1,
+      };
+    });
+  }, [resolvedPrefill]);
+
+  const { query: searchPrefill, token: refreshToken } = prefillState;
+
+  return (
+    <div className="container-lg py-4" style={{ maxWidth: "960px" }}>
+      <SearchPanel
+        displayedTitle="Search Inventory Items"
+        prefilledQuery={searchPrefill}
+        refreshToken={refreshToken}
+        tableName="items"
+        allowDelete
+      />
+      <TreeView />
+    </div>
+  );
+};
+
+export default SearchItemsPage;
   }, [location.search, xyz]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure the ledger search page tracks URL-provided queries and nudges SearchPanel to refresh immediately
- ensure the item search page mirrors the same URL-prefill handling so shared links execute automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1f4af93b8832b9d8fa7f9849ee556