### PR TITLE
Add sender whitelist handling for generic email ingestion

### DIFF
--- a/backend/app/config_loader.py
+++ b/backend/app/config_loader.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from collections.abc import Mapping
 from typing import Any, Optional
@@ -22,6 +23,9 @@ _REPO_ROOT_PREFIX = "<REPO_ROOT>/"
 _PIN_OPEN_EXPIRY_CONFIG_KEY = "pin_open_expiry_hours"
 _PIN_OPEN_EXPIRY_DEFAULT_HOURS = 36
 
+_EMAIL_WHITELIST_CACHE: Optional[tuple[str, ...]] = None
+_EMAIL_WHITELIST_CACHE_READY = False
+
 def _read_json_file(path: Path) -> dict:
     """Read JSON from disk, returning an empty mapping on failure."""
     try:
@@ -34,6 +38,30 @@ def load_app_config() -> dict:
     """Return the raw JSON configuration for the application."""
     return _read_json_file(CONFIG_PATH)
 
+def _normalize_email_whitelist(raw_value: Any) -> tuple[str, ...]:
+    """Convert raw configuration values into a normalized whitelist tuple."""
+    normalized_entries = []
+
+    def _append_entry(candidate: Any) -> None:
+        """Add cleaned whitelist entries while ignoring invalid data types."""
+        if not isinstance(candidate, str):
+            return
+        cleaned = candidate.strip().lower()
+        if not cleaned:
+            return
+        if cleaned in normalized_entries:
+            return
+        normalized_entries.append(cleaned)
+
+    if isinstance(raw_value, str):
+        for piece in re.split(r"[;,\s]+", raw_value):
+            _append_entry(piece)
+    elif isinstance(raw_value, list):
+        for item in raw_value:
+            _append_entry(item)
+
+    return tuple(normalized_entries)
+
 def _coerce_positive_number(value: Any, fallback: int) -> int:
     """Convert unknown input into a positive integer number of hours."""
     try:
@@ -43,6 +71,24 @@ def _coerce_positive_number(value: Any, fallback: int) -> int:
     if numeric <= 0:
         return int(fallback)
     return int(numeric)
+
+def get_email_whitelist(cfg: Optional[Mapping[str, Any]] = None) -> list[str]:
+    """Return the cached list of permitted email sender fragments."""
+    global _EMAIL_WHITELIST_CACHE, _EMAIL_WHITELIST_CACHE_READY
+    if _EMAIL_WHITELIST_CACHE_READY:
+        return list(_EMAIL_WHITELIST_CACHE or ())
+
+    if cfg is None:
+        cfg = load_app_config()
+
+    raw_value: Any = None
+    if isinstance(cfg, Mapping):
+        raw_value = cfg.get("email_whitelist")
+
+    whitelist_tuple = _normalize_email_whitelist(raw_value)
+    _EMAIL_WHITELIST_CACHE = whitelist_tuple
+    _EMAIL_WHITELIST_CACHE_READY = True
+    return list(whitelist_tuple)
 
 def get_pin_open_expiry_hours(cfg: Optional[Mapping[str, Any]] = None) -> int:
     """Resolve the configured window (in hours) for keeping pins open."""

--- a/backend/email_utils/gmail.py
+++ b/backend/email_utils/gmail.py
@@ -9,6 +9,7 @@ import logging
 import sys
 import uuid
 from datetime import datetime, timedelta
+from email.utils import parseaddr
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -339,6 +340,7 @@ class GmailChecker(EmailChecker):
             h.get("name", "").lower(): h.get("value", "")
             for h in msg.get("payload", {}).get("headers", [])
         }
+        sender_email = parseaddr(headers.get("from", ""))[1] or None
         subject = headers.get("subject", "")
         message_id = msg.get("id") or ""
         normalized_id = GmailChecker._normalize_gmail_id(message_id)
@@ -356,6 +358,7 @@ class GmailChecker(EmailChecker):
             text_body,
             gmail_link,
             None,
+            sender_email,
         )
         raw_identifier = normalized_id or message_id or ""
         # Gmail message identifiers arrive as hexadecimal strings that need to live in the bytea column as raw bytes.

--- a/backend/email_utils/imap.py
+++ b/backend/email_utils/imap.py
@@ -10,6 +10,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from email import message_from_bytes
 from email.header import decode_header, make_header
+from email.utils import parseaddr
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 # Ensure repository imports function when executing the file directly.
@@ -185,6 +186,8 @@ class ImapChecker(EmailChecker):
         msg = message_from_bytes(msg_bytes)
         subject = ImapChecker._decode_header_value(msg.get("Subject"))
         message_id = ImapChecker._decode_header_value(msg.get("Message-ID")) or uid
+        from_header = ImapChecker._decode_header_value(msg.get("From"))
+        sender_email = parseaddr(from_header)[1] or None
         html_body, text_body = ImapChecker._extract_bodies(msg)
         email_date = EmailChecker.parse_email_date(msg.get("Date"))
         ingestion = EmailChecker.ingest_invoice_from_email(
@@ -196,6 +199,7 @@ class ImapChecker(EmailChecker):
             text_body,
             None,
             None,
+            sender_email,
         )
         # Persist the canonical hexadecimal UID as raw bytes so the bytea column stays consistent.
         payload: Dict[str, Any] = {


### PR DESCRIPTION
## Summary
- cache the email whitelist from appconfig.json and normalize it for matching
- require generic email ingestions to match a configured sender whitelist before inserting invoices
- pass the parsed sender email address from Gmail and IMAP handlers into the shared ingestion helper

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e21831f2a8832bb5b137d75fd12e85