### PR TITLE
Link modal slug to item page

### DIFF
--- a/frontend/src/app/components/TreeView.tsx
+++ b/frontend/src/app/components/TreeView.tsx
@@ -878,7 +878,21 @@ const TreeView: React.FC = () => {
             {modalNode ? (
               <div style={{ marginTop: "8px", color: "#555" }}>
                 <div>ID: {modalNode.data.id}</div>
-                <div>Slug: {modalNode.data.slug || "(none)"}</div>
+                <div>
+                  {/* Present the slug as a direct hyperlink so users can easily open the item details view. */}
+                  Slug: {modalNode.data.slug ? (
+                    <a
+                      href={`/item/${modalNode.data.slug}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={MODAL_LINK_STYLE}
+                    >
+                      {modalNode.data.slug}
+                    </a>
+                  ) : (
+                    "(none)"
+                  )}
+                </div>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary
- display the modal slug as a hyperlink that opens the item detail route in a new tab
- add an explanatory comment describing why the slug is linked

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e33a084d20832b9b3567c942275aab