### PR TITLE
Fix AiShopHandler registration

### DIFF
--- a/backend/shop_handler/shop_handler.py
+++ b/backend/shop_handler/shop_handler.py
@@ -213,7 +213,6 @@ class ShopHandler:
             ("digikey_handler", "DigiKeyHandler"),
             ("mcmastercarr_handler", "McMasterCarrHandler"),
             ("ebay_handler", "EbayHandler"),
-            ("ai_shop_handler", "AiShopHandler"),
         )
 
         handler_package = cls._determine_handler_package()
@@ -224,6 +223,9 @@ class ShopHandler:
             module = importlib.import_module(module_path)
             handler_type = getattr(module, class_name)
             resolved_handlers.append(handler_type)
+
+        # AiShopHandler is defined in this module, so we append it directly without importing.
+        resolved_handlers.append(AiShopHandler)
 
         return tuple(resolved_handlers)
 


### PR DESCRIPTION
## Summary
- stop importing AiShopHandler as if it lived in a separate module
- register AiShopHandler from the current module after the dynamic imports, with a clarifying comment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e743b7549c832bab23e83e383bcc5f