### PR TITLE
Fix actor context handling for history logging

### DIFF
--- a/backend/app/history.py
+++ b/backend/app/history.py
@@ -45,10 +45,13 @@ def _resolve_username() -> Optional[str]:
     a username explicitly.
     """
 
-    if get_actor_ctx():
-        ctx = get_actor_ctx()
-        if ctx["display"]:
-            return ctx["display"]
+    actor_context = get_actor_ctx()
+    if isinstance(actor_context, Mapping):
+        display_value = actor_context.get("display")
+        if display_value is not None:
+            candidate = str(display_value).strip()
+            if candidate:
+                return candidate
     if has_request_context():
         raw_username = session.get("user_id")  # type: ignore[index]
         if isinstance(raw_username, str):

--- a/backend/automation/actor_context.py
+++ b/backend/automation/actor_context.py
@@ -1,16 +1,57 @@
 from contextvars import ContextVar
 
-actor_ctx = ContextVar("actor_ctx", default={
+from typing import Dict, Optional
+
+# The default context captures every field that callers expect to read.
+# Each helper function works with copies so the shared ContextVar default
+# stays immutable and predictable across threads and async tasks.
+_DEFAULT_CONTEXT: Dict[str, Optional[str]] = {
     "executed_by_type": "unknown",
     "user": None,
     "actor": None,
     "origin": "unknown",
-    "display": "unknown",
-})
+    "display": None,
+}
 
-def as_user(username: str, origin="ui:request"):
-    global actor_ctx
-    actor_ctx.set({
+# The ContextVar stores the most recent actor information for the current execution context.
+actor_ctx: ContextVar[Dict[str, Optional[str]]] = ContextVar(
+    "actor_ctx",
+    default=_DEFAULT_CONTEXT.copy(),
+)
+
+def _build_default_context() -> Dict[str, Optional[str]]:
+    """Return a fresh dictionary containing the canonical context keys."""
+    return _DEFAULT_CONTEXT.copy()
+
+def _replace_context(overrides: Dict[str, Optional[str]]) -> Dict[str, Optional[str]]:
+    """Replace the entire context using defaults plus the supplied overrides."""
+    fresh = _build_default_context()
+    fresh.update(overrides)
+    actor_ctx.set(fresh)
+    return fresh
+
+def _ensure_context() -> Dict[str, Optional[str]]:
+    """Guarantee that the ContextVar holds every expected key with safe defaults."""
+    current = actor_ctx.get()
+    if isinstance(current, dict):
+        normalized = _build_default_context()
+        normalized.update(current)
+        # Refresh the ContextVar so future reads observe the normalized structure.
+        actor_ctx.set(normalized)
+        return normalized
+    return _replace_context({})
+
+def _merge_context(overrides: Dict[str, Optional[str]]) -> Dict[str, Optional[str]]:
+    """Update the current context while preserving unspecified values."""
+    base = _ensure_context()
+    merged = dict(base)
+    merged.update(overrides)
+    actor_ctx.set(merged)
+    return merged
+
+def as_user(username: str, origin: str = "ui:request") -> Dict[str, Optional[str]]:
+    """Record that a human user initiated the current action."""
+    return _replace_context({
         "executed_by_type": "user",
         "user": username,
         "actor": None,
@@ -18,34 +59,39 @@ def as_user(username: str, origin="ui:request"):
         "display": username,
     })
 
-def as_agent_for(username: str, actor: str = "system", origin="unknown"):
-    global actor_ctx
-    actor_ctx.set({
+def as_agent_for(username: str, actor: str = "system", origin: str = "unknown") -> Dict[str, Optional[str]]:
+    """Describe work performed by an automated actor on behalf of a user."""
+    return _replace_context({
         "executed_by_type": "user+agent",
         "user": username,
         "actor": actor,
         "origin": origin,
-        "display": f"{username}/{actor}"
+        "display": f"{username}/{actor}",
     })
 
-def as_system(origin: str = "unknown", actor: str = "system"):
-    global actor_ctx
-    actor_ctx.set({
+def as_system(origin: str = "unknown", actor: str = "system") -> Dict[str, Optional[str]]:
+    """Capture a context for fully automated system activity."""
+    return _replace_context({
         "executed_by_type": "agent",
         "user": None,
         "actor": actor,
         "origin": origin,
-        "display": f"/{actor}"
+        "display": f"/{actor}",
     })
 
-def overlay_actor(origin: str = "unknown", actor: str = "system"):
-    global actor_ctx
-    actor_ctx["executed_by_type"] = "user+agent" if actor_ctx["user"] else "agent"
-    actor_ctx["actor"] = actor
-    actor_ctx["origin"] = origin
-    username = actor_ctx["user"] if actor_ctx["user"] else ""
-    actor_ctx["display"] = f"{username}/{actor}"
+def overlay_actor(origin: str = "unknown", actor: str = "system") -> Dict[str, Optional[str]]:
+    """Augment the current context with an additional actor while keeping the user."""
+    base = _ensure_context()
+    username = base.get("user") or ""
+    executed_by_type = "user+agent" if username else "agent"
+    display_value = f"{username}/{actor}" if username else f"/{actor}"
+    return _merge_context({
+        "executed_by_type": executed_by_type,
+        "actor": actor,
+        "origin": origin,
+        "display": display_value,
+    })
 
-def get_actor_ctx():
-    global actor_ctx
-    return actor_ctx
+def get_actor_ctx() -> Dict[str, Optional[str]]:
+    """Return a copy of the current actor context for read-only callers."""
+    return dict(_ensure_context())


### PR DESCRIPTION
## Summary
- normalize the actor context helper so it always returns a mapping with predictable keys
- update history username resolution to read the display name safely from the actor context

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e755af76d4832b9229083e719556d7