### PR TITLE
Order seen email queries by recency

### DIFF
--- a/backend/email_utils/gmail.py
+++ b/backend/email_utils/gmail.py
@@ -202,7 +202,8 @@ class GmailChecker(EmailChecker):
         engine = get_engine()
         try:
             with engine.connect() as conn:
-                result = conn.execute(text("SELECT email_uuid FROM gmail_seen"))
+                # Order by date_seen so the newest processed messages appear first for downstream usage.
+                result = conn.execute(text("SELECT email_uuid FROM gmail_seen ORDER BY date_seen DESC"))
                 # Convert stored bytea values back into canonical hexadecimal strings for comparison.
                 seen_ids: set[int] = set()
                 for row in result:

--- a/backend/email_utils/imap.py
+++ b/backend/email_utils/imap.py
@@ -111,7 +111,8 @@ class ImapChecker(EmailChecker):
         engine = get_engine()
         try:
             with engine.connect() as conn:
-                result = conn.execute(text("SELECT email_uuid FROM imail_seen"))
+                # Order by date_seen to prioritise the most recently processed IMAP entries.
+                result = conn.execute(text("SELECT email_uuid FROM imail_seen ORDER BY date_seen DESC"))
                 seen: List[str] = []
                 for row in result:
                     hex_value = bytea_to_hex_str(row[0])


### PR DESCRIPTION
## Summary
- ensure Gmail seen message lookups return the most recent entries first by ordering on date_seen
- apply the same most-recent ordering for IMAP seen message retrievals to keep deduplication consistent

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e762b64560832ba7a7cfdcf06dcad7