### PR TITLE
Fix pgvector insert syntax for metatext updates

### DIFF
--- a/backend/app/metatext.py
+++ b/backend/app/metatext.py
@@ -425,12 +425,13 @@ def update_metatext(input: str, check_closest_n: int = 3) -> str:
 
             vector_literal = _format_vector_literal(vector)
             # Cast the stored literal so the pgvector column receives the correct type and avoids the array versus vector mismatch.
+            # Using CAST rather than the shorthand :: syntax keeps SQLAlchemy from merging the type name into the bind parameter.
 
             conn.execute(
                 text(
                     f"""
 INSERT INTO public.{table_name} (word, vec)
-VALUES (:word, :vec::vector)
+VALUES (:word, CAST(:vec AS vector))
 ON CONFLICT (word) DO UPDATE
 SET vec = EXCLUDED.vec,
     date_updated = now();


### PR DESCRIPTION
## Summary
- ensure tag word embedding inserts use CAST(:vec AS vector) so psycopg does not reject the parameter syntax
- document in-code why the explicit CAST is required to keep SQLAlchemy parameter handling stable

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e8b57393d4832b982691710376f69d