### PR TITLE
Fix stale state when navigating to new item form

### DIFF
--- a/frontend/src/pages/ItemPage.tsx
+++ b/frontend/src/pages/ItemPage.tsx
@@ -259,8 +259,13 @@ const ItemPage: React.FC = () => {
     let ignore = false;
     async function load() {
       if (isNewFromUrl) {
-        setItem((prev) => ({ ...EMPTY_ITEM, ...prev, is_staging: true }));
+        // Reset the working copy entirely so a request for a brand new item never inherits stale identifiers.
+        setError("");
+        setLoading(false);
+        setItem({ ...EMPTY_ITEM, is_staging: true });
         setIsReadOnly(false);
+        setRefreshToken(0);
+        setContainmentRefreshToken(0);
         return;
       }
       try {


### PR DESCRIPTION
## Summary
- clear the item editor state when navigating to `/item/new` so old identifiers and details do not persist
- reset related loading and refresh flags to keep child panels from referencing the previous item

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e8cd9a66a0832b9d1e5912027a2293