### PR TITLE
Fix relative imports for standalone tools

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -17,7 +17,7 @@ from sqlalchemy import create_engine, MetaData, Table, select, text
 from sqlalchemy.engine import Engine, Connection
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from sqlalchemy.exc import NoSuchTableError
-import app.helpers as helpers
+from . import helpers  # Use a relative import so standalone tools can find helpers
 
 
 def _coerce_mapping(value: Any) -> Dict[str, Any]:

--- a/backend/app/history.py
+++ b/backend/app/history.py
@@ -10,8 +10,8 @@ from flask import Blueprint, jsonify, has_request_context, session
 from sqlalchemy import text
 from sqlalchemy.engine import Engine, RowMapping
 
-from app.db import get_engine, get_or_create_session, update_db_row_by_dict
-from app.helpers import normalize_pg_uuid, coerce_identifier_to_uuid, build_callstack_string
+from .db import get_engine, get_or_create_session, update_db_row_by_dict  # Local import keeps tooling paths reliable
+from .helpers import normalize_pg_uuid, coerce_identifier_to_uuid, build_callstack_string  # Local import keeps tooling paths reliable
 from .user_login import login_required
 from automation.actor_context import get_actor_ctx
 


### PR DESCRIPTION
## Summary
- switch database module to use a relative helpers import so the backup tool can load it without a special PYTHONPATH
- update history module to use relative imports for database and helper utilities, keeping standalone scripts happy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8d2c796fc832baf269a7fad19dd52